### PR TITLE
Feat: Business 페이지 구현 및 통합

### DIFF
--- a/src/components/business/Cafe27b.tsx
+++ b/src/components/business/Cafe27b.tsx
@@ -1,0 +1,314 @@
+import { useState } from 'react';
+
+const Cafe27b = () => {
+  const [currentMenuPage, setCurrentMenuPage] = useState(0);
+  const [currentProductPage, setCurrentProductPage] = useState(0);
+  const [currentMainImage, setCurrentMainImage] = useState(0);
+
+  const mainImages = [
+    { id: 1, name: '이미지1' },
+    { id: 2, name: '이미지2' },
+    { id: 3, name: '이미지3' },
+  ];
+
+  const menuItems = [
+    { id: 1, name: '아메리카노' },
+    { id: 2, name: '라떼' },
+    { id: 3, name: '카푸치노' },
+    { id: 4, name: '모카' },
+    { id: 5, name: '에스프레소' },
+    { id: 6, name: '바닐라라떼' },
+  ];
+
+  const productItems = [
+    { id: 1, name: '상품1' },
+    { id: 2, name: '상품2' },
+    { id: 3, name: '상품3' },
+    { id: 4, name: '상품4' },
+    { id: 5, name: '상품5' },
+    { id: 6, name: '상품6' },
+  ];
+
+  const itemsPerPage = 3;
+  const productItemsPerPage = 5;
+  const totalMenuPages = Math.ceil(menuItems.length / itemsPerPage);
+  const totalProductPages = Math.ceil(productItems.length / productItemsPerPage);
+
+  const nextMainImage = () => {
+    setCurrentMainImage((prev) => (prev + 1) % mainImages.length);
+  };
+
+  const prevMainImage = () => {
+    setCurrentMainImage((prev) => (prev - 1 + mainImages.length) % mainImages.length);
+  };
+
+  const nextMenuPage = () => {
+    setCurrentMenuPage((prev) => (prev + 1) % totalMenuPages);
+  };
+
+  const prevMenuPage = () => {
+    setCurrentMenuPage((prev) => (prev - 1 + totalMenuPages) % totalMenuPages);
+  };
+
+  const nextProductPage = () => {
+    setCurrentProductPage((prev) => (prev + 1) % totalProductPages);
+  };
+
+  const prevProductPage = () => {
+    setCurrentProductPage((prev) => (prev - 1 + totalProductPages) % totalProductPages);
+  };
+
+  return (
+    <div className="w-full py-8">
+      {/* 헤더 섹션 */}
+      <div className="text-center mb-12">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">카페27b</h2>
+        <div className="w-16 h-1 bg-black mx-auto mb-6"></div>
+        <p className="text-base sm:text-lg text-gray-600 leading-relaxed max-w-4xl mx-auto px-4">
+          카페27b는 화전마음의 도시재생 거점공간이자, 우주·드론·항공대 콘셉트가 어우러진 특별한 마을
+          카페입니다. 누구에게나 열린 이곳은 커피 한 잔 너머로 주민의 대화가 시작되고, 다양한 실험과
+          협업이 이뤄지는 복합문화 공간이기도 합니다.
+        </p>
+      </div>
+
+      {/* 메인 이미지 캐러셀 */}
+      <div className="mb-16 max-w-5xl mx-auto">
+        <div className="relative flex items-center">
+          {/* 좌측 화살표 */}
+          <button
+            onClick={prevMainImage}
+            className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-12 w-8 h-8 bg-white bg-opacity-50 rounded-full flex items-center justify-center hover:bg-opacity-70 z-10"
+          >
+            <svg className="w-4 h-4 text-gray-600" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+
+          {/* 이미지 */}
+          <div className="w-full bg-gray-200 rounded-lg h-64 sm:h-80 flex items-center justify-center">
+            <span className="text-gray-500 text-lg">{mainImages[currentMainImage].name}</span>
+          </div>
+
+          {/* 우측 화살표 */}
+          <button
+            onClick={nextMainImage}
+            className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-12 w-8 h-8 bg-white bg-opacity-50 rounded-full flex items-center justify-center hover:bg-opacity-70 z-10"
+          >
+            <svg className="w-4 h-4 text-gray-600" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* 페이지네이션 점 */}
+        <div className="flex justify-center mt-4 space-x-2">
+          {mainImages.map((_, index) => (
+            <div
+              key={index}
+              className={`w-2 h-2 rounded-full ${
+                index === currentMainImage ? 'bg-blue-600' : 'bg-gray-400'
+              }`}
+            ></div>
+          ))}
+        </div>
+      </div>
+
+      {/* 카페 메뉴 */}
+      <div className="w-full mb-16 bg-[#E8E4DB80] p-8">
+        <div className="max-w-5xl mx-auto">
+          <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">카페 메뉴</h3>
+          <h4 className="text-lg sm:text-xl text-gray-700 mb-8">카페메뉴</h4>
+
+          <div className="relative">
+            {/* 좌우 화살표 */}
+            <button
+              onClick={prevMenuPage}
+              className="absolute left-4 top-1/2 -translate-y-1/2 w-8 h-8 bg-white bg-opacity-50 rounded-full flex items-center justify-center hover:bg-opacity-70 z-10"
+            >
+              <svg className="w-4 h-4 text-gray-600" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+            <button
+              onClick={nextMenuPage}
+              className="absolute right-4 top-1/2 -translate-y-1/2 w-8 h-8 bg-white bg-opacity-50 rounded-full flex items-center justify-center hover:bg-opacity-70 z-10"
+            >
+              <svg className="w-4 h-4 text-gray-600" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+
+            {/* 메뉴 카드들 */}
+            <div className="flex justify-center space-x-6 px-12">
+              {menuItems
+                .slice(currentMenuPage * itemsPerPage, (currentMenuPage + 1) * itemsPerPage)
+                .map((item) => (
+                  <div key={item.id} className="flex-shrink-0 w-56">
+                    <div className="bg-gray-200 rounded-lg h-56 flex items-center justify-center mb-3">
+                      <span className="text-gray-500 text-lg">이미지</span>
+                    </div>
+                    <p className="text-center text-sm font-medium text-gray-900">{item.name}</p>
+                  </div>
+                ))}
+            </div>
+
+            {/* 페이지네이션 점 */}
+            <div className="flex justify-center mt-6 space-x-2">
+              {Array.from({ length: totalMenuPages }, (_, index) => (
+                <div
+                  key={index}
+                  className={`w-2 h-2 rounded-full ${
+                    index === currentMenuPage ? 'bg-blue-600' : 'bg-gray-400'
+                  }`}
+                ></div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 케이터링 서비스 안내 */}
+      <div className="mb-16 max-w-5xl mx-auto">
+        <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">케이터링 서비스 안내</h3>
+        <h4 className="text-lg sm:text-xl text-gray-700 mb-8">케이터링 서비스 안내</h4>
+
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 max-w-4xl mx-auto mb-8">
+          {[1, 2, 3, 4].map((item) => (
+            <div key={item} className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+              <div className="bg-gray-200 rounded-lg h-32 flex items-center justify-center mb-3">
+                <span className="text-gray-500 text-sm">이미지</span>
+              </div>
+              <div className="text-center">
+                <p className="text-sm font-medium text-gray-900 mb-1">주요 구성 예시</p>
+                <p className="text-xs text-gray-600">커피/차 + 수제 쿠키</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="max-w-4xl mx-auto px-4">
+          <p className="text-sm sm:text-base text-gray-600 leading-relaxed text-center">
+            조합의 행사, 회의, 주민모임 등을 위해 카페27b는 자체 케이터링 서비스를 운영하고
+            있습니다. 로컬푸드, 제철 재료, 건강한 간식으로 구성된 메뉴는 사전 예약을 통해
+            커스터마이징할 수 있습니다.
+          </p>
+        </div>
+      </div>
+
+      {/* 이동카페 서비스 안내 */}
+      <div className="w-full mb-16 bg-[#E8E4DB80] p-8">
+        <div className="max-w-5xl mx-auto">
+          <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
+            이동카페 서비스 안내
+          </h3>
+          <h4 className="text-lg sm:text-xl text-gray-700 mb-8">이동 카페 서비스 안내</h4>
+
+          <div className="grid grid-cols-2 gap-4 max-w-5xl mx-auto mb-6">
+            <div className="bg-gray-200 rounded-lg h-56 flex items-center justify-center">
+              <span className="text-gray-500 text-lg">이미지</span>
+            </div>
+            <div className="bg-gray-200 rounded-lg h-56 flex items-center justify-center">
+              <span className="text-gray-500 text-lg">이미지</span>
+            </div>
+            <div className="bg-gray-200 rounded-lg h-56 flex items-center justify-center">
+              <span className="text-gray-500 text-lg">이미지</span>
+            </div>
+            <div className="bg-orange-100 rounded-lg h-56 p-6 flex items-center justify-center">
+              <div className="text-center">
+                <p className="text-sm font-medium text-gray-900 mb-2">
+                  행사 현장, 야외 워크숍, 지역축제 등
+                </p>
+                <p className="text-xs text-gray-600 mb-2">
+                  필요한 공간으로 직접 찾아가는 이동카페 서비스를 제공합니다.
+                </p>
+                <p className="text-xs text-gray-600">
+                  접수된 일정에 따라 카페27b의 맛과 분위기를 현장으로 전달합니다.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 판매 상품 소개 */}
+      <div className="mb-16 max-w-5xl mx-auto">
+        <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">판매 상품 소개</h3>
+        <h4 className="text-lg sm:text-xl text-gray-700 mb-8">판매상품 소개</h4>
+
+        <div className="relative">
+          {/* 좌우 화살표 */}
+          <button
+            onClick={prevProductPage}
+            className="absolute left-4 top-1/2 -translate-y-1/2 w-8 h-8 bg-white bg-opacity-50 rounded-full flex items-center justify-center hover:bg-opacity-70 z-10"
+          >
+            <svg className="w-4 h-4 text-gray-600" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={nextProductPage}
+            className="absolute right-4 top-1/2 -translate-y-1/2 w-8 h-8 bg-white bg-opacity-50 rounded-full flex items-center justify-center hover:bg-opacity-70 z-10"
+          >
+            <svg className="w-4 h-4 text-gray-600" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+
+          {/* 상품 카드들 */}
+          <div className="flex justify-center space-x-4 px-12">
+            {productItems
+              .slice(
+                currentProductPage * productItemsPerPage,
+                (currentProductPage + 1) * productItemsPerPage
+              )
+              .map((item) => (
+                <div key={item.id} className="flex-shrink-0 w-40">
+                  <div className="bg-gray-200 rounded-lg h-40 flex items-center justify-center">
+                    <span className="text-gray-500 text-sm">이미지</span>
+                  </div>
+                </div>
+              ))}
+          </div>
+
+          {/* 페이지네이션 점 */}
+          <div className="flex justify-center mt-6 space-x-2">
+            {Array.from({ length: totalProductPages }, (_, index) => (
+              <div
+                key={index}
+                className={`w-2 h-2 rounded-full ${
+                  index === currentProductPage ? 'bg-blue-600' : 'bg-gray-400'
+                }`}
+              ></div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Cafe27b;

--- a/src/components/business/EventsEducation.tsx
+++ b/src/components/business/EventsEducation.tsx
@@ -1,0 +1,96 @@
+const EventsEducation = () => {
+  return (
+    <div className="w-full py-8">
+      {/* 헤더 섹션 */}
+      <div className="text-center mb-12">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">
+          행사 기획 및 교육 체험 사업
+        </h2>
+        <div className="w-16 h-1 bg-black mx-auto mb-6"></div>
+        <p className="text-base sm:text-lg text-gray-600 leading-relaxed max-w-4xl mx-auto px-4">
+          주민들이 직접 아이디어를 제안하고 기획하여 실행하는 생활 밀착형 교육과 체험 프로그램을
+          운영하고 있습니다.
+        </p>
+      </div>
+
+      {/* 핵심 프로그램 소개 */}
+      <div className="w-full mb-16 bg-[#2C2E5A1A] p-8">
+        <div className="max-w-5xl mx-auto">
+          <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2 text-center">
+            핵심 프로그램 소개
+          </h3>
+          <h4 className="text-lg sm:text-xl text-gray-700 mb-8 text-center">핵심 프로그램 소개</h4>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {[1, 2, 3, 4].map((item) => (
+              <div
+                key={item}
+                className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm"
+              >
+                <div className="bg-gray-300 h-48 flex items-center justify-center">
+                  <span className="text-gray-500 text-lg">이미지</span>
+                </div>
+                <div className="p-4">
+                  <h5 className="text-lg font-bold text-gray-900 mb-2">프로그램명</h5>
+                  <p className="text-sm text-gray-600">마을을 기록하고 공유하는 시민참여형 활동</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* 운영 방식 소개 */}
+      <div className="w-full mb-16 mx-auto">
+        <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2 text-center">
+          운영 방식 소개
+        </h3>
+        <h4 className="text-lg sm:text-xl text-gray-700 mb-8 text-center">운영 방식 소개</h4>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-5xl mx-auto">
+          {/* Box 01 */}
+          <div className="bg-blue-900 text-white p-6 rounded-lg">
+            <div className="text-2xl font-bold mb-4">01</div>
+            <ul className="space-y-2">
+              <li className="text-sm">연 2~3회 공모형/공개모집형 기획 가능</li>
+              <li className="text-sm">연 2~3회 공모형/공개모집형 기획 가능</li>
+              <li className="text-sm">연 2~3회 공모형/공개모집형 기획 가능</li>
+            </ul>
+          </div>
+
+          {/* Box 02 */}
+          <div className="bg-white border border-gray-200 p-6 rounded-lg">
+            <div className="text-2xl font-bold mb-4 text-gray-900">02</div>
+            <ul className="space-y-2">
+              <li className="text-sm text-gray-700">주민 아이디어 제안 → 실행까지 연결</li>
+              <li className="text-sm text-gray-700">주민 아이디어 제안 → 실행까지 연결</li>
+              <li className="text-sm text-gray-700">주민 아이디어 제안 → 실행까지 연결</li>
+            </ul>
+          </div>
+
+          {/* Box 03 */}
+          <div className="bg-white border border-gray-200 p-6 rounded-lg">
+            <div className="text-2xl font-bold mb-4 text-gray-900">03</div>
+            <ul className="space-y-2">
+              <li className="text-sm text-gray-700">주민 아이디어 제안 → 실행까지 연결</li>
+              <li className="text-sm text-gray-700">주민 아이디어 제안 → 실행까지 연결</li>
+              <li className="text-sm text-gray-700">주민 아이디어 제안 → 실행까지 연결</li>
+            </ul>
+          </div>
+
+          {/* Box 04 */}
+          <div className="bg-blue-900 text-white p-6 rounded-lg">
+            <div className="text-2xl font-bold mb-4">04</div>
+            <ul className="space-y-2">
+              <li className="text-sm">연 2~3회 공모형/공개모집형 기획 가능</li>
+              <li className="text-sm">연 2~3회 공모형/공개모집형 기획 가능</li>
+              <li className="text-sm">연 2~3회 공모형/공개모집형 기획 가능</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EventsEducation;

--- a/src/components/business/LocalActivation.tsx
+++ b/src/components/business/LocalActivation.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+
+const LocalActivation = () => {
+  const [currentEventImage, setCurrentEventImage] = useState(0);
+
+  const eventImages = [
+    { id: 1, name: '이미지1' },
+    { id: 2, name: '이미지2' },
+    { id: 3, name: '이미지3' },
+  ];
+
+  const nextEventImage = () => {
+    setCurrentEventImage((prev) => (prev + 1) % eventImages.length);
+  };
+
+  const prevEventImage = () => {
+    setCurrentEventImage((prev) => (prev - 1 + eventImages.length) % eventImages.length);
+  };
+
+  return (
+    <div className="w-full py-8">
+      {/* 헤더 섹션 */}
+      <div className="text-center mb-12">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">지역 활성화 사업</h2>
+        <div className="w-16 h-1 bg-black mx-auto mb-6"></div>
+      </div>
+
+      {/* 지역 공동체 행사 */}
+      <div className="mb-16">
+        <div className="max-w-5xl mx-auto px-4">
+          <div className="mb-8">
+            <h3 className="text-xl sm:text-2xl font-semibold text-gray-800 mb-2">
+              지역 공동체 행사
+            </h3>
+            <p className="text-sm sm:text-base text-gray-600">지역 공동체 행사</p>
+          </div>
+          <div className="relative">
+            {/* 좌측 화살표 */}
+            <button
+              onClick={prevEventImage}
+              className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-12 w-8 h-8 rounded-full flex items-center justify-center z-10"
+              style={{ backgroundColor: '#1e3a8a' }}
+            >
+              <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+
+            {/* 메인 이미지 */}
+            <div className="relative w-full bg-gray-200 rounded-lg h-64 sm:h-80 flex items-center justify-center">
+              <span className="text-gray-500 text-lg">{eventImages[currentEventImage].name}</span>
+            </div>
+
+            {/* 오버레이 텍스트 */}
+            <div className="absolute -bottom-6 sm:-bottom-8 lg:-bottom-10 -right-1 sm:-right-2 lg:-right-3 bg-white rounded-lg px-4 sm:px-6 lg:px-8 py-2 sm:py-3 lg:py-4 shadow-lg w-64 sm:w-80 md:w-96 lg:w-[448px] xl:w-[512px] h-24 sm:h-28 md:h-32 lg:h-36 xl:h-40">
+              <div className="flex items-center justify-center h-full">
+                <span className="text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl font-medium text-gray-800">
+                  지역 공동체 행사
+                </span>
+              </div>
+            </div>
+
+            {/* 우측 화살표 */}
+            <button
+              onClick={nextEventImage}
+              className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-12 w-8 h-8 rounded-full flex items-center justify-center z-10"
+              style={{ backgroundColor: '#1e3a8a' }}
+            >
+              <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* 지역과 함께하는 사업 */}
+      <div className="mb-16" style={{ backgroundColor: '#A692D11A' }}>
+        <div className="max-w-5xl mx-auto px-4 py-8">
+          <div className="mb-8">
+            <h3 className="text-xl sm:text-2xl font-semibold text-gray-800 mb-2">
+              지역과 함께하는 사업
+            </h3>
+            <p className="text-sm sm:text-base text-gray-600">지역과 함께 하는 사업</p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {/* 카드 1 */}
+            <div
+              className="rounded-lg p-8 flex items-center space-x-6"
+              style={{ backgroundColor: '#2C2E5A80' }}
+            >
+              <div className="w-20 h-20 bg-gray-300 rounded flex items-center justify-center flex-shrink-0">
+                <span className="text-sm text-gray-600">아이콘</span>
+              </div>
+              <div className="flex-1">
+                <h4 className="text-xl font-medium text-gray-800 mb-2">지역사랑 상품권</h4>
+                <p className="text-base text-gray-600 mb-1">지역사랑 상품권</p>
+                <p className="text-base text-gray-600">지역사랑 상품권</p>
+              </div>
+            </div>
+
+            {/* 카드 2 */}
+            <div
+              className="rounded-lg p-8 flex items-center space-x-6"
+              style={{ backgroundColor: '#2C2E5A80' }}
+            >
+              <div className="w-20 h-20 bg-gray-300 rounded flex items-center justify-center flex-shrink-0">
+                <span className="text-sm text-gray-600">아이콘</span>
+              </div>
+              <div className="flex-1">
+                <h4 className="text-xl font-medium text-gray-800 mb-2">지역사랑 상품권</h4>
+                <p className="text-base text-gray-600 mb-1">지역사랑 상품권</p>
+                <p className="text-base text-gray-600">지역사랑 상품권</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 주민 역량 강화 교육 */}
+      <div className="mb-16">
+        <div className="max-w-5xl mx-auto px-4">
+          <div className="mb-8">
+            <h3 className="text-xl sm:text-2xl font-semibold text-gray-800 mb-2">
+              주민 역량 강화 교육
+            </h3>
+            <p className="text-sm sm:text-base text-gray-600">주민 역량 강화 교육</p>
+          </div>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            {/* 이미지 영역 */}
+            <div className="bg-gray-200 rounded-lg h-64 sm:h-80 flex items-center justify-center">
+              <span className="text-gray-500 text-lg">이미지</span>
+            </div>
+
+            {/* 텍스트 영역 */}
+            <div className="flex flex-col justify-between h-64 sm:h-80">
+              <div className="mb-4">
+                <h4 className="text-lg font-semibold text-gray-800 mb-2">우선순위 설정</h4>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  중요한 작업을 먼저 처리함으로써 효율성을 높일 수 있습니다.
+                </p>
+              </div>
+
+              <div className="mb-4">
+                <h4 className="text-lg font-semibold text-gray-800 mb-2">시간 블록 기법</h4>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  작업에 특정 시간을 할당하여 집중력을 유지할 수 있습니다.
+                </p>
+              </div>
+
+              <div className="mb-4">
+                <h4 className="text-lg font-semibold text-gray-800 mb-2">Pomodoro 기법</h4>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  25분 집중 작업 후 5분 휴식을 반복하여 집중력과 피로를 관리할 수 있습니다.
+                </p>
+              </div>
+
+              <div>
+                <p className="text-sm text-gray-600 leading-relaxed">
+                  이러한 방법들을 통해 디지털 환경에서 효과적으로 시간을 관리할 수 있습니다.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LocalActivation;

--- a/src/components/business/UrbanRegenerationHub.tsx
+++ b/src/components/business/UrbanRegenerationHub.tsx
@@ -1,0 +1,163 @@
+const UrbanRegenerationHub = () => {
+  return (
+    <div className="w-full py-8">
+      {/* 헤더 섹션 */}
+      <div className="text-center mb-12">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">
+          도시재생 거점공간 운영 사업
+        </h2>
+        <div className="w-16 h-1 bg-black mx-auto mb-6"></div>
+        <p className="text-base sm:text-lg text-gray-600 leading-relaxed max-w-4xl mx-auto px-4">
+          화전마을사회적협동조합은 도시재생의 핵심 가치인 주민 주도성을 실현하기 위해 <br />
+          일상 속 마을 거점공간을 직접 운영하고 있습니다. <br />이 공간은 단순한 장소를 넘어, 주민의
+          만남, 논의, 실행, 공유가 이어지는 플랫폼 역할을 수행하고 있습니다.
+        </p>
+      </div>
+
+      {/* 카페 운영 실무 아카데미 */}
+      <div className="w-full mb-16 bg-[#E8E4DB80] p-8">
+        <div className="max-w-5xl mx-auto">
+          <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
+            카페 운영 실무 아카데미
+          </h3>
+          <h4 className="text-lg sm:text-xl text-gray-700 mb-8">카페 운영 실무 아카데미</h4>
+
+          {/* 카드 컨테이너 */}
+          <div className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+            <div className="grid lg:grid-cols-2">
+              {/* 이미지 영역 */}
+              <div className="bg-gray-200 h-64 sm:h-80 flex items-center justify-center">
+                <span className="text-gray-500 text-lg">이미지</span>
+              </div>
+
+              {/* 정보 영역 */}
+              <div className="p-6 flex flex-col h-full">
+                <h5 className="text-xl font-bold text-gray-900 mb-4">제목</h5>
+                <div className="space-y-3 flex-1">
+                  <div className="flex items-center text-gray-600">
+                    <svg
+                      className="w-5 h-5 mr-2 text-gray-400"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                    <span>경기 고양시 덕양구 화전동 183-33</span>
+                  </div>
+                  <div className="flex items-center text-gray-600">
+                    <svg
+                      className="w-5 h-5 mr-2 text-gray-400"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                    <span>회의, 소모임, 공유활동</span>
+                  </div>
+                  <div className="flex items-center text-gray-600">
+                    <svg
+                      className="w-5 h-5 mr-2 text-gray-400"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                    <span>누구나 예약 가능, 주민회의 자주 열림</span>
+                  </div>
+                </div>
+
+                {/* 네비게이션 버튼 */}
+                <div className="flex justify-end space-x-2">
+                  <button className="w-8 h-8 rounded-full bg-blue-600 hover:bg-blue-700 flex items-center justify-center">
+                    <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                      <path
+                        fillRule="evenodd"
+                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                  <button className="w-8 h-8 rounded-full bg-blue-600 hover:bg-blue-700 flex items-center justify-center">
+                    <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                      <path
+                        fillRule="evenodd"
+                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 조합 역량 강화 교육 */}
+      <div className="mb-16 max-w-5xl mx-auto">
+        <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">조합 역량 강화 교육</h3>
+        <h4 className="text-lg sm:text-xl text-gray-700 mb-8">조합 역량 강화 교육</h4>
+
+        <div className="grid lg:grid-cols-2 gap-8 items-center">
+          {/* 이미지 영역 */}
+          <div className="bg-gray-200 rounded-lg h-64 sm:h-80 flex items-center justify-center">
+            <span className="text-gray-500 text-lg">이미지</span>
+          </div>
+
+          {/* 교육 프로그램 카드들 */}
+          <div className="space-y-3 h-64 sm:h-80 flex flex-col justify-between">
+            <div className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
+              <span className="text-gray-700 font-medium">조합 역량 강화 교육</span>
+            </div>
+            <div className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
+              <span className="text-gray-700 font-medium">조합 역량 강화 교육</span>
+            </div>
+            <div className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
+              <span className="text-gray-700 font-medium">조합 역량 강화 교육</span>
+            </div>
+            <div className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
+              <span className="text-gray-700 font-medium">조합 역량 강화 교육</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 선진지 탐방 프로그램 */}
+      <div className="mb-16 max-w-5xl mx-auto">
+        <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">선진지 탐방 프로그램</h3>
+        <h4 className="text-lg sm:text-xl text-gray-700 mb-8">선진지 탐방 프로그램</h4>
+
+        <div className="bg-gray-200 rounded-lg h-64 sm:h-80 flex items-center justify-center">
+          <span className="text-gray-500 text-lg">이미지</span>
+        </div>
+      </div>
+
+      {/* 하단 설명 텍스트 */}
+      <div className="text-center max-w-4xl mx-auto px-4">
+        <p className="text-sm sm:text-base text-gray-600 leading-relaxed">
+          화전마을의 거점공간은 단순히 회의를 위한 장소나 일시적인 프로그램을 위한 공간이 아닙니다.
+          <br />
+          이곳은 주민이 직접 만나고, 이야기하고, 아이디어를 모아 실제 실행으로 옮기는 '마을 변화의
+          플랫폼' 역할을 수행하고 있습니다. <br />
+          무엇보다 중요한 점은, 이 공간이 주민 누구에게나 열려 있다는 것입니다. <br />
+          마을을 변화시키는 일은 특별한 기획자가 아닌, 이곳을 오가며 이야기 나누는 주민들로부터
+          시작되기 때문입니다. <br />
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default UrbanRegenerationHub;

--- a/src/components/business/index.ts
+++ b/src/components/business/index.ts
@@ -1,2 +1,4 @@
 export { default as UrbanRegenerationHub } from './UrbanRegenerationHub';
 export { default as EventsEducation } from './EventsEducation';
+export { default as Cafe27b } from './Cafe27b';
+export { default as LocalActivation } from './LocalActivation';

--- a/src/components/business/index.ts
+++ b/src/components/business/index.ts
@@ -1,1 +1,2 @@
 export { default as UrbanRegenerationHub } from './UrbanRegenerationHub';
+export { default as EventsEducation } from './EventsEducation';

--- a/src/components/business/index.ts
+++ b/src/components/business/index.ts
@@ -1,0 +1,1 @@
+export { default as UrbanRegenerationHub } from './UrbanRegenerationHub';

--- a/src/pages/member/Business.tsx
+++ b/src/pages/member/Business.tsx
@@ -1,6 +1,6 @@
 import { TabNavigation, type TabItem } from '@/components/ui/TabNavigation';
 import { useTabState } from '@/hooks/useTabState';
-import { UrbanRegenerationHub } from '@/components/business';
+import { UrbanRegenerationHub, EventsEducation } from '@/components/business';
 
 function Business() {
   const tabs: TabItem[] = [
@@ -17,35 +17,7 @@ function Business() {
       case 'urban-regeneration':
         return <UrbanRegenerationHub />;
       case 'events-education':
-        return (
-          <div className="py-8">
-            <h2 className="text-2xl font-bold mb-4">행사 기획 및 교육 체험 사업</h2>
-            <div className="space-y-4">
-              <p className="text-gray-600 leading-relaxed">
-                다양한 행사 기획과 교육 프로그램을 통해 지역주민들의 참여와 소통을 도모하고,
-                지역사회의 활성화와 발전에 기여합니다.
-              </p>
-              <div className="grid md:grid-cols-2 gap-6 mt-6">
-                <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">주요 사업</h3>
-                  <ul className="space-y-2 text-gray-600">
-                    <li>• 지역 축제 및 행사 기획</li>
-                    <li>• 교육 프로그램 운영</li>
-                    <li>• 체험 활동 지원</li>
-                  </ul>
-                </div>
-                <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">기대효과</h3>
-                  <ul className="space-y-2 text-gray-600">
-                    <li>• 지역 문화 활성화</li>
-                    <li>• 주민 참여 확대</li>
-                    <li>• 지역 정체성 강화</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
+        return <EventsEducation />;
       case 'cafe27b':
         return (
           <div className="py-8">

--- a/src/pages/member/Business.tsx
+++ b/src/pages/member/Business.tsx
@@ -1,6 +1,11 @@
 import { TabNavigation, type TabItem } from '@/components/ui/TabNavigation';
 import { useTabState } from '@/hooks/useTabState';
-import { UrbanRegenerationHub, EventsEducation } from '@/components/business';
+import {
+  UrbanRegenerationHub,
+  EventsEducation,
+  Cafe27b,
+  LocalActivation,
+} from '@/components/business';
 
 function Business() {
   const tabs: TabItem[] = [
@@ -19,65 +24,9 @@ function Business() {
       case 'events-education':
         return <EventsEducation />;
       case 'cafe27b':
-        return (
-          <div className="py-8">
-            <h2 className="text-2xl font-bold mb-4">카페27b</h2>
-            <div className="space-y-4">
-              <p className="text-gray-600 leading-relaxed">
-                화전 지역의 대표적인 커뮤니티 카페로, 지역주민들의 만남의 공간이자 다양한 문화활동의
-                중심지 역할을 하고 있습니다.
-              </p>
-              <div className="grid md:grid-cols-2 gap-6 mt-6">
-                <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">운영 정보</h3>
-                  <ul className="space-y-2 text-gray-600">
-                    <li>• 운영시간: 평일 09:00-22:00</li>
-                    <li>• 휴무일: 매주 월요일</li>
-                    <li>• 위치: 화전 중앙로 27번길</li>
-                  </ul>
-                </div>
-                <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">서비스</h3>
-                  <ul className="space-y-2 text-gray-600">
-                    <li>• 커피 및 음료 서비스</li>
-                    <li>• 간단한 식사 메뉴</li>
-                    <li>• 모임 공간 대여</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
+        return <Cafe27b />;
       case 'local-activation':
-        return (
-          <div className="py-8">
-            <h2 className="text-2xl font-bold mb-4">지역 활성화 사업</h2>
-            <div className="space-y-4">
-              <p className="text-gray-600 leading-relaxed">
-                화전 지역의 경제적, 사회적, 문화적 활성화를 위한 다양한 사업을 추진하여 지역발전과
-                주민복지 향상에 기여합니다.
-              </p>
-              <div className="grid md:grid-cols-2 gap-6 mt-6">
-                <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">경제 활성화</h3>
-                  <ul className="space-y-2 text-gray-600">
-                    <li>• 상권 활성화 지원</li>
-                    <li>• 창업 지원 프로그램</li>
-                    <li>• 지역 특산품 개발</li>
-                  </ul>
-                </div>
-                <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">사회 활성화</h3>
-                  <ul className="space-y-2 text-gray-600">
-                    <li>• 주민 참여 프로그램</li>
-                    <li>• 자원봉사 활동</li>
-                    <li>• 지역 네트워크 구축</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
+        return <LocalActivation />;
       default:
         return null;
     }

--- a/src/pages/member/Business.tsx
+++ b/src/pages/member/Business.tsx
@@ -1,5 +1,6 @@
 import { TabNavigation, type TabItem } from '@/components/ui/TabNavigation';
 import { useTabState } from '@/hooks/useTabState';
+import { UrbanRegenerationHub } from '@/components/business';
 
 function Business() {
   const tabs: TabItem[] = [
@@ -14,59 +15,31 @@ function Business() {
   const renderTabContent = () => {
     switch (activeTab) {
       case 'urban-regeneration':
-        return (
-          <div className="py-8">
-            <h2 className="text-2xl font-bold mb-4">도시재생 거점공간 운영 사업</h2>
-            <div className="space-y-4">
-              <p className="text-gray-600 leading-relaxed">
-                화전 지역의 도시재생을 위한 거점공간을 운영하여 지역주민들의 소통과 협력을 도모하고,
-                지속가능한 도시발전의 기반을 마련합니다.
-              </p>
-              <div className="grid md:grid-cols-2 gap-6 mt-6">
-                <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">주요 사업</h3>
-                  <ul className="space-y-2 text-gray-600">
-                    <li>• 거점공간 시설 운영</li>
-                    <li>• 지역주민 모임 지원</li>
-                    <li>• 도시재생 프로그램 기획</li>
-                  </ul>
-                </div>
-                <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">기대효과</h3>
-                  <ul className="space-y-2 text-gray-600">
-                    <li>• 지역 커뮤니티 활성화</li>
-                    <li>• 도시재생 참여 확대</li>
-                    <li>• 지역경제 활성화</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
+        return <UrbanRegenerationHub />;
       case 'events-education':
         return (
           <div className="py-8">
             <h2 className="text-2xl font-bold mb-4">행사 기획 및 교육 체험 사업</h2>
             <div className="space-y-4">
               <p className="text-gray-600 leading-relaxed">
-                다양한 문화행사와 교육 프로그램을 통해 지역주민들의 문화적 경험을 풍부하게 하고,
-                학습과 성장의 기회를 제공합니다.
+                다양한 행사 기획과 교육 프로그램을 통해 지역주민들의 참여와 소통을 도모하고,
+                지역사회의 활성화와 발전에 기여합니다.
               </p>
               <div className="grid md:grid-cols-2 gap-6 mt-6">
                 <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">행사 프로그램</h3>
+                  <h3 className="text-lg font-semibold mb-3">주요 사업</h3>
                   <ul className="space-y-2 text-gray-600">
-                    <li>• 문화축제 및 공연</li>
-                    <li>• 전시회 및 체험전</li>
-                    <li>• 지역 특색 행사</li>
+                    <li>• 지역 축제 및 행사 기획</li>
+                    <li>• 교육 프로그램 운영</li>
+                    <li>• 체험 활동 지원</li>
                   </ul>
                 </div>
                 <div className="bg-gray-50 p-6 rounded-lg">
-                  <h3 className="text-lg font-semibold mb-3">교육 프로그램</h3>
+                  <h3 className="text-lg font-semibold mb-3">기대효과</h3>
                   <ul className="space-y-2 text-gray-600">
-                    <li>• 평생교육 과정</li>
-                    <li>• 직업훈련 프로그램</li>
-                    <li>• 문화예술 교육</li>
+                    <li>• 지역 문화 활성화</li>
+                    <li>• 주민 참여 확대</li>
+                    <li>• 지역 정체성 강화</li>
                   </ul>
                 </div>
               </div>
@@ -139,16 +112,16 @@ function Business() {
   };
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="max-w-6xl mx-auto">
+    <div className="w-full py-8">
+      <div className="max-w-6xl mx-auto px-4">
         <TabNavigation
           tabs={tabs}
           value={activeTab}
           onValueChange={handleTabChange}
           className="mb-8"
         />
-        {renderTabContent()}
       </div>
+      {renderTabContent()}
     </div>
   );
 }


### PR DESCRIPTION
## 주요 변경사항

### 1. Cafe27b 컴포넌트 구현
- 메인 이미지 캐러셀 (3개 이미지 순환)
- 카페 메뉴 캐러셀 (3개씩 표시)
- 판매 상품 소개 캐러셀 (5개씩 표시)
- 케이터링 서비스 안내 (2x2 그리드)
- 이동카페 서비스 안내 (2x2 그리드)
- 완전 반응형 디자인

### 2. 지역 활성화 사업 컴포넌트 구현
- 3개 섹션: 지역 공동체 행사, 지역과 함께하는 사업, 주민 역량 강화 교육
- 이미지 캐러셀 기능 (3개 이미지 순환)
- 반응형 오버레이 텍스트 (1920px: 800x280, 1440px: 600x210)
- 커스텀 색상 적용
- 완전 반응형 디자인

### 3. Business 페이지 통합
- 4개 탭 완성: 도시재생, 행사기획, 카페27b, 지역활성화
- business/index.ts에 새 컴포넌트들 export 추가

## 테스트 방법
1. /member/business 경로로 이동
2. 각 탭 클릭하여 UI 및 기능 확인
3. 반응형 디자인 및 캐러셀 기능 테스트