### PR TITLE
Refactor: 컴포넌트 하드코딩된 데이터를 별도 데이터 파일로 분리

### DIFF
--- a/src/components/business/Cafe27b.tsx
+++ b/src/components/business/Cafe27b.tsx
@@ -1,33 +1,24 @@
 import { useState } from 'react';
+import type { MainImage, MenuItem, ProductItem, CateringService, MobileCafeService } from './data';
 
-const Cafe27b = () => {
+interface Cafe27bProps {
+  mainImages?: MainImage[];
+  menuItems?: MenuItem[];
+  productItems?: ProductItem[];
+  cateringServices?: CateringService[];
+  mobileCafeServices?: MobileCafeService[];
+}
+
+const Cafe27b = ({
+  mainImages = [],
+  menuItems = [],
+  productItems = [],
+  cateringServices = [],
+  mobileCafeServices = [],
+}: Cafe27bProps) => {
   const [currentMenuPage, setCurrentMenuPage] = useState(0);
   const [currentProductPage, setCurrentProductPage] = useState(0);
   const [currentMainImage, setCurrentMainImage] = useState(0);
-
-  const mainImages = [
-    { id: 1, name: '이미지1' },
-    { id: 2, name: '이미지2' },
-    { id: 3, name: '이미지3' },
-  ];
-
-  const menuItems = [
-    { id: 1, name: '아메리카노' },
-    { id: 2, name: '라떼' },
-    { id: 3, name: '카푸치노' },
-    { id: 4, name: '모카' },
-    { id: 5, name: '에스프레소' },
-    { id: 6, name: '바닐라라떼' },
-  ];
-
-  const productItems = [
-    { id: 1, name: '상품1' },
-    { id: 2, name: '상품2' },
-    { id: 3, name: '상품3' },
-    { id: 4, name: '상품4' },
-    { id: 5, name: '상품5' },
-    { id: 6, name: '상품6' },
-  ];
 
   const itemsPerPage = 3;
   const productItemsPerPage = 5;
@@ -189,14 +180,17 @@ const Cafe27b = () => {
         <h4 className="text-lg sm:text-xl text-gray-700 mb-8">케이터링 서비스 안내</h4>
 
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 max-w-4xl mx-auto mb-8">
-          {[1, 2, 3, 4].map((item) => (
-            <div key={item} className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+          {cateringServices.map((service) => (
+            <div
+              key={service.id}
+              className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+            >
               <div className="bg-gray-200 rounded-lg h-32 flex items-center justify-center mb-3">
                 <span className="text-gray-500 text-sm">이미지</span>
               </div>
               <div className="text-center">
-                <p className="text-sm font-medium text-gray-900 mb-1">주요 구성 예시</p>
-                <p className="text-xs text-gray-600">커피/차 + 수제 쿠키</p>
+                <p className="text-sm font-medium text-gray-900 mb-1">{service.title}</p>
+                <p className="text-xs text-gray-600">{service.description}</p>
               </div>
             </div>
           ))}
@@ -220,28 +214,23 @@ const Cafe27b = () => {
           <h4 className="text-lg sm:text-xl text-gray-700 mb-8">이동 카페 서비스 안내</h4>
 
           <div className="grid grid-cols-2 gap-4 max-w-5xl mx-auto mb-6">
-            <div className="bg-gray-200 rounded-lg h-56 flex items-center justify-center">
-              <span className="text-gray-500 text-lg">이미지</span>
-            </div>
-            <div className="bg-gray-200 rounded-lg h-56 flex items-center justify-center">
-              <span className="text-gray-500 text-lg">이미지</span>
-            </div>
-            <div className="bg-gray-200 rounded-lg h-56 flex items-center justify-center">
-              <span className="text-gray-500 text-lg">이미지</span>
-            </div>
-            <div className="bg-orange-100 rounded-lg h-56 p-6 flex items-center justify-center">
-              <div className="text-center">
-                <p className="text-sm font-medium text-gray-900 mb-2">
-                  행사 현장, 야외 워크숍, 지역축제 등
-                </p>
-                <p className="text-xs text-gray-600 mb-2">
-                  필요한 공간으로 직접 찾아가는 이동카페 서비스를 제공합니다.
-                </p>
-                <p className="text-xs text-gray-600">
-                  접수된 일정에 따라 카페27b의 맛과 분위기를 현장으로 전달합니다.
-                </p>
+            {mobileCafeServices.map((service) => (
+              <div
+                key={service.id}
+                className={`rounded-lg h-56 flex items-center justify-center ${
+                  service.isTextCard ? 'bg-orange-100 p-6' : 'bg-gray-200'
+                }`}
+              >
+                {service.isTextCard ? (
+                  <div className="text-center">
+                    <p className="text-sm font-medium text-gray-900 mb-2">{service.title}</p>
+                    <p className="text-xs text-gray-600">{service.description}</p>
+                  </div>
+                ) : (
+                  <span className="text-gray-500 text-lg">이미지</span>
+                )}
               </div>
-            </div>
+            ))}
           </div>
         </div>
       </div>

--- a/src/components/business/EventsEducation.tsx
+++ b/src/components/business/EventsEducation.tsx
@@ -1,4 +1,11 @@
-const EventsEducation = () => {
+import type { EventCard } from './data';
+import { eventCards as defaultEventCards } from './data';
+
+interface EventsEducationProps {
+  eventCards?: EventCard[];
+}
+
+const EventsEducation = ({ eventCards = defaultEventCards }: EventsEducationProps) => {
   return (
     <div className="w-full py-8">
       {/* 헤더 섹션 */}
@@ -22,17 +29,17 @@ const EventsEducation = () => {
           <h4 className="text-lg sm:text-xl text-gray-700 mb-8 text-center">핵심 프로그램 소개</h4>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {[1, 2, 3, 4].map((item) => (
+            {eventCards.map((card) => (
               <div
-                key={item}
+                key={card.id}
                 className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm"
               >
                 <div className="bg-gray-300 h-48 flex items-center justify-center">
                   <span className="text-gray-500 text-lg">이미지</span>
                 </div>
                 <div className="p-4">
-                  <h5 className="text-lg font-bold text-gray-900 mb-2">프로그램명</h5>
-                  <p className="text-sm text-gray-600">마을을 기록하고 공유하는 시민참여형 활동</p>
+                  <h5 className="text-lg font-bold text-gray-900 mb-2">{card.title}</h5>
+                  <p className="text-sm text-gray-600">{card.description}</p>
                 </div>
               </div>
             ))}

--- a/src/components/business/LocalActivation.tsx
+++ b/src/components/business/LocalActivation.tsx
@@ -1,13 +1,20 @@
 import { useState } from 'react';
+import type { EventImage, CommunityProject, EducationMethod } from './data';
 
-const LocalActivation = () => {
+interface LocalActivationProps {
+  eventImages?: EventImage[];
+  communityProjects?: CommunityProject[];
+  educationMethods?: EducationMethod[];
+  educationSummary?: string;
+}
+
+const LocalActivation = ({
+  eventImages = [],
+  communityProjects = [],
+  educationMethods = [],
+  educationSummary = '',
+}: LocalActivationProps) => {
   const [currentEventImage, setCurrentEventImage] = useState(0);
-
-  const eventImages = [
-    { id: 1, name: '이미지1' },
-    { id: 2, name: '이미지2' },
-    { id: 3, name: '이미지3' },
-  ];
 
   const nextEventImage = () => {
     setCurrentEventImage((prev) => (prev + 1) % eventImages.length);
@@ -93,35 +100,21 @@ const LocalActivation = () => {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            {/* 카드 1 */}
-            <div
-              className="rounded-lg p-8 flex items-center space-x-6"
-              style={{ backgroundColor: '#2C2E5A80' }}
-            >
-              <div className="w-20 h-20 bg-gray-300 rounded flex items-center justify-center flex-shrink-0">
-                <span className="text-sm text-gray-600">아이콘</span>
+            {communityProjects.map((project) => (
+              <div
+                key={project.id}
+                className="rounded-lg p-8 flex items-center space-x-6"
+                style={{ backgroundColor: '#2C2E5A80' }}
+              >
+                <div className="w-20 h-20 bg-gray-300 rounded flex items-center justify-center flex-shrink-0">
+                  <span className="text-sm text-gray-600">아이콘</span>
+                </div>
+                <div className="flex-1">
+                  <h4 className="text-xl font-medium text-gray-800 mb-2">{project.title}</h4>
+                  <p className="text-base text-gray-600 mb-1">{project.description}</p>
+                </div>
               </div>
-              <div className="flex-1">
-                <h4 className="text-xl font-medium text-gray-800 mb-2">지역사랑 상품권</h4>
-                <p className="text-base text-gray-600 mb-1">지역사랑 상품권</p>
-                <p className="text-base text-gray-600">지역사랑 상품권</p>
-              </div>
-            </div>
-
-            {/* 카드 2 */}
-            <div
-              className="rounded-lg p-8 flex items-center space-x-6"
-              style={{ backgroundColor: '#2C2E5A80' }}
-            >
-              <div className="w-20 h-20 bg-gray-300 rounded flex items-center justify-center flex-shrink-0">
-                <span className="text-sm text-gray-600">아이콘</span>
-              </div>
-              <div className="flex-1">
-                <h4 className="text-xl font-medium text-gray-800 mb-2">지역사랑 상품권</h4>
-                <p className="text-base text-gray-600 mb-1">지역사랑 상품권</p>
-                <p className="text-base text-gray-600">지역사랑 상품권</p>
-              </div>
-            </div>
+            ))}
           </div>
         </div>
       </div>
@@ -143,32 +136,18 @@ const LocalActivation = () => {
 
             {/* 텍스트 영역 */}
             <div className="flex flex-col justify-between h-64 sm:h-80">
-              <div className="mb-4">
-                <h4 className="text-lg font-semibold text-gray-800 mb-2">우선순위 설정</h4>
-                <p className="text-sm text-gray-600 leading-relaxed">
-                  중요한 작업을 먼저 처리함으로써 효율성을 높일 수 있습니다.
-                </p>
-              </div>
+              {educationMethods.map((method, index) => (
+                <div key={method.id} className={index < educationMethods.length - 1 ? 'mb-4' : ''}>
+                  <h4 className="text-lg font-semibold text-gray-800 mb-2">{method.title}</h4>
+                  <p className="text-sm text-gray-600 leading-relaxed">{method.description}</p>
+                </div>
+              ))}
 
-              <div className="mb-4">
-                <h4 className="text-lg font-semibold text-gray-800 mb-2">시간 블록 기법</h4>
-                <p className="text-sm text-gray-600 leading-relaxed">
-                  작업에 특정 시간을 할당하여 집중력을 유지할 수 있습니다.
-                </p>
-              </div>
-
-              <div className="mb-4">
-                <h4 className="text-lg font-semibold text-gray-800 mb-2">Pomodoro 기법</h4>
-                <p className="text-sm text-gray-600 leading-relaxed">
-                  25분 집중 작업 후 5분 휴식을 반복하여 집중력과 피로를 관리할 수 있습니다.
-                </p>
-              </div>
-
-              <div>
-                <p className="text-sm text-gray-600 leading-relaxed">
-                  이러한 방법들을 통해 디지털 환경에서 효과적으로 시간을 관리할 수 있습니다.
-                </p>
-              </div>
+              {educationSummary && (
+                <div>
+                  <p className="text-sm text-gray-600 leading-relaxed">{educationSummary}</p>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/business/UrbanRegenerationHub.tsx
+++ b/src/components/business/UrbanRegenerationHub.tsx
@@ -1,4 +1,18 @@
-const UrbanRegenerationHub = () => {
+import type { AcademyCard, EducationCard } from './data';
+import {
+  academyCards as defaultAcademyCards,
+  educationCards as defaultEducationCards,
+} from './data';
+
+interface UrbanRegenerationHubProps {
+  academyCards?: AcademyCard[];
+  educationCards?: EducationCard[];
+}
+
+const UrbanRegenerationHub = ({
+  academyCards = defaultAcademyCards,
+  educationCards = defaultEducationCards,
+}: UrbanRegenerationHubProps) => {
   return (
     <div className="w-full py-8">
       {/* 헤더 섹션 */}
@@ -23,85 +37,69 @@ const UrbanRegenerationHub = () => {
           <h4 className="text-lg sm:text-xl text-gray-700 mb-8">카페 운영 실무 아카데미</h4>
 
           {/* 카드 컨테이너 */}
-          <div className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
-            <div className="grid lg:grid-cols-2">
-              {/* 이미지 영역 */}
-              <div className="bg-gray-200 h-64 sm:h-80 flex items-center justify-center">
-                <span className="text-gray-500 text-lg">이미지</span>
-              </div>
-
-              {/* 정보 영역 */}
-              <div className="p-6 flex flex-col h-full">
-                <h5 className="text-xl font-bold text-gray-900 mb-4">제목</h5>
-                <div className="space-y-3 flex-1">
-                  <div className="flex items-center text-gray-600">
-                    <svg
-                      className="w-5 h-5 mr-2 text-gray-400"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                    <span>경기 고양시 덕양구 화전동 183-33</span>
-                  </div>
-                  <div className="flex items-center text-gray-600">
-                    <svg
-                      className="w-5 h-5 mr-2 text-gray-400"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                    <span>회의, 소모임, 공유활동</span>
-                  </div>
-                  <div className="flex items-center text-gray-600">
-                    <svg
-                      className="w-5 h-5 mr-2 text-gray-400"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                    <span>누구나 예약 가능, 주민회의 자주 열림</span>
-                  </div>
+          {academyCards.map((card) => (
+            <div
+              key={card.id}
+              className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm"
+            >
+              <div className="grid lg:grid-cols-2">
+                {/* 이미지 영역 */}
+                <div className="bg-gray-200 h-64 sm:h-80 flex items-center justify-center">
+                  <span className="text-gray-500 text-lg">이미지</span>
                 </div>
 
-                {/* 네비게이션 버튼 */}
-                <div className="flex justify-end space-x-2">
-                  <button className="w-8 h-8 rounded-full bg-blue-600 hover:bg-blue-700 flex items-center justify-center">
-                    <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
-                      <path
-                        fillRule="evenodd"
-                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </button>
-                  <button className="w-8 h-8 rounded-full bg-blue-600 hover:bg-blue-700 flex items-center justify-center">
-                    <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
-                      <path
-                        fillRule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </button>
+                {/* 정보 영역 */}
+                <div className="p-6 flex flex-col h-full">
+                  <h5 className="text-xl font-bold text-gray-900 mb-4">{card.title}</h5>
+                  <p className="text-gray-600 mb-4">{card.description}</p>
+                  <div className="space-y-3 flex-1">
+                    <div className="flex items-center text-gray-600">
+                      <svg
+                        className="w-5 h-5 mr-2 text-gray-400"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                      <span>{card.period}</span>
+                    </div>
+                    <div className="flex items-center text-gray-600">
+                      <svg
+                        className="w-5 h-5 mr-2 text-gray-400"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                      <span>{card.target}</span>
+                    </div>
+                    <div className="flex items-center text-gray-600">
+                      <svg
+                        className="w-5 h-5 mr-2 text-gray-400"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                      <span>{card.capacity}</span>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          ))}
         </div>
       </div>
 
@@ -118,18 +116,14 @@ const UrbanRegenerationHub = () => {
 
           {/* 교육 프로그램 카드들 */}
           <div className="space-y-3 h-64 sm:h-80 flex flex-col justify-between">
-            <div className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
-              <span className="text-gray-700 font-medium">조합 역량 강화 교육</span>
-            </div>
-            <div className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
-              <span className="text-gray-700 font-medium">조합 역량 강화 교육</span>
-            </div>
-            <div className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
-              <span className="text-gray-700 font-medium">조합 역량 강화 교육</span>
-            </div>
-            <div className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
-              <span className="text-gray-700 font-medium">조합 역량 강화 교육</span>
-            </div>
+            {educationCards.map((card) => (
+              <div
+                key={card.id}
+                className="bg-purple-100 rounded-lg p-4 text-center flex-1 flex items-center justify-center"
+              >
+                <span className="text-gray-700 font-medium">{card.title}</span>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/src/components/business/data/cafe27bData.ts
+++ b/src/components/business/data/cafe27bData.ts
@@ -1,0 +1,204 @@
+export interface MainImage {
+  id: number;
+  name: string;
+  src: string;
+  alt: string;
+}
+
+export interface MenuItem {
+  id: number;
+  name: string;
+  price: string;
+  description: string;
+  image: string;
+}
+
+export interface ProductItem {
+  id: number;
+  name: string;
+  price: string;
+  description: string;
+  image: string;
+}
+
+export interface CateringService {
+  id: number;
+  title: string;
+  description: string;
+  image: string;
+}
+
+export interface MobileCafeService {
+  id: number;
+  title: string;
+  description: string;
+  image: string;
+  isTextCard?: boolean;
+}
+
+export const mainImages: MainImage[] = [
+  {
+    id: 1,
+    name: '이미지1',
+    src: '/images/cafe/main1.jpg',
+    alt: '카페27b 메인 이미지 1',
+  },
+  {
+    id: 2,
+    name: '이미지2',
+    src: '/images/cafe/main2.jpg',
+    alt: '카페27b 메인 이미지 2',
+  },
+  {
+    id: 3,
+    name: '이미지3',
+    src: '/images/cafe/main3.jpg',
+    alt: '카페27b 메인 이미지 3',
+  },
+];
+
+export const menuItems: MenuItem[] = [
+  {
+    id: 1,
+    name: '아메리카노',
+    price: '4,500원',
+    description: '깔끔하고 진한 에스프레소',
+    image: '/images/cafe/menu/americano.jpg',
+  },
+  {
+    id: 2,
+    name: '라떼',
+    price: '5,000원',
+    description: '부드러운 우유와 에스프레소의 조화',
+    image: '/images/cafe/menu/latte.jpg',
+  },
+  {
+    id: 3,
+    name: '카푸치노',
+    price: '5,000원',
+    description: '진한 에스프레소와 거품의 완벽한 조화',
+    image: '/images/cafe/menu/cappuccino.jpg',
+  },
+  {
+    id: 4,
+    name: '모카',
+    price: '5,500원',
+    description: '초콜릿과 에스프레소의 달콤한 만남',
+    image: '/images/cafe/menu/mocha.jpg',
+  },
+  {
+    id: 5,
+    name: '에스프레소',
+    price: '3,500원',
+    description: '진한 에스프레소의 원맛',
+    image: '/images/cafe/menu/espresso.jpg',
+  },
+  {
+    id: 6,
+    name: '바닐라라떼',
+    price: '5,500원',
+    description: '바닐라 시럽이 들어간 달콤한 라떼',
+    image: '/images/cafe/menu/vanilla-latte.jpg',
+  },
+];
+
+export const productItems: ProductItem[] = [
+  {
+    id: 1,
+    name: '원두',
+    price: '15,000원',
+    description: '프리미엄 원두 200g',
+    image: '/images/cafe/products/beans1.jpg',
+  },
+  {
+    id: 2,
+    name: '텀블러',
+    price: '25,000원',
+    description: '스테인리스 텀블러 500ml',
+    image: '/images/cafe/products/tumbler1.jpg',
+  },
+  {
+    id: 3,
+    name: '머그컵',
+    price: '18,000원',
+    description: '세라믹 머그컵 세트',
+    image: '/images/cafe/products/mug1.jpg',
+  },
+  {
+    id: 4,
+    name: '드립백',
+    price: '8,000원',
+    description: '원두 드립백 10개입',
+    image: '/images/cafe/products/dripbag1.jpg',
+  },
+  {
+    id: 5,
+    name: '시럽',
+    price: '12,000원',
+    description: '바닐라 시럽 500ml',
+    image: '/images/cafe/products/syrup1.jpg',
+  },
+  {
+    id: 6,
+    name: '쿠키',
+    price: '6,000원',
+    description: '수제 쿠키 6개입',
+    image: '/images/cafe/products/cookie1.jpg',
+  },
+];
+
+export const cateringServices: CateringService[] = [
+  {
+    id: 1,
+    title: '기업 행사',
+    description: '회의, 세미나, 워크샵 등 기업 행사 케이터링',
+    image: '/images/cafe/catering/corporate.jpg',
+  },
+  {
+    id: 2,
+    title: '결혼식',
+    description: '소규모 결혼식 및 리셉션 케이터링',
+    image: '/images/cafe/catering/wedding.jpg',
+  },
+  {
+    id: 3,
+    title: '생일파티',
+    description: '가족, 친구들과의 특별한 순간을 위한 케이터링',
+    image: '/images/cafe/catering/birthday.jpg',
+  },
+  {
+    id: 4,
+    title: '기타 행사',
+    description: '다양한 특별한 순간을 위한 맞춤형 케이터링',
+    image: '/images/cafe/catering/other.jpg',
+  },
+];
+
+export const mobileCafeServices: MobileCafeService[] = [
+  {
+    id: 1,
+    title: '이동카페 서비스',
+    description: '원하는 장소로 찾아가는 이동카페 서비스',
+    image: '/images/cafe/mobile/mobile1.jpg',
+  },
+  {
+    id: 2,
+    title: '이벤트 카페',
+    description: '축제, 행사장에서 운영하는 특별한 카페',
+    image: '/images/cafe/mobile/mobile2.jpg',
+  },
+  {
+    id: 3,
+    title: '야외 카페',
+    description: '공원, 해변 등 야외에서 즐기는 카페 경험',
+    image: '/images/cafe/mobile/mobile3.jpg',
+  },
+  {
+    id: 4,
+    title: '이동카페 서비스 안내',
+    description:
+      '이동카페 서비스는 최소 2시간부터 예약 가능하며, 다양한 메뉴와 장비를 제공합니다. 행사 규모와 요구사항에 맞춰 맞춤형 서비스를 제공해드립니다.',
+    image: '',
+    isTextCard: true,
+  },
+];

--- a/src/components/business/data/eventsEducationData.ts
+++ b/src/components/business/data/eventsEducationData.ts
@@ -1,0 +1,79 @@
+export interface EventCard {
+  id: number;
+  title: string;
+  description: string;
+  date: string;
+  location: string;
+  capacity: string;
+  image: string;
+}
+
+export interface EducationCard {
+  id: number;
+  title: string;
+  description: string;
+  period: string;
+  target: string;
+  capacity: string;
+  image: string;
+}
+
+export const eventCards: EventCard[] = [
+  {
+    id: 1,
+    title: '화전 마을 축제',
+    description: '화전 마을의 전통과 문화를 소개하는 대규모 축제입니다.',
+    date: '2024.05.15',
+    location: '화전 마을 광장',
+    capacity: '500명',
+    image: '/images/event1.jpg',
+  },
+  {
+    id: 2,
+    title: '지역 특산품 전시회',
+    description: '화전 지역의 우수한 특산품들을 소개하는 전시회입니다.',
+    date: '2024.06.20',
+    location: '화전 문화센터',
+    capacity: '200명',
+    image: '/images/event2.jpg',
+  },
+  {
+    id: 3,
+    title: '가족 체험 행사',
+    description: '가족 단위로 참여할 수 있는 다양한 체험 프로그램입니다.',
+    date: '2024.07.10',
+    location: '화전 체험관',
+    capacity: '100명',
+    image: '/images/event3.jpg',
+  },
+  {
+    id: 4,
+    title: '가족 체험 행사',
+    description: '가족 단위로 참여할 수 있는 다양한 체험 프로그램입니다.',
+    date: '2024.07.10',
+    location: '화전 체험관',
+    capacity: '100명',
+    image: '/images/event3.jpg',
+  },
+];
+
+export const educationCards: EducationCard[] = [
+  {
+    id: 1,
+    title: '지역 문화 교육',
+    description: '화전 지역의 역사와 문화를 배우는 교육 프로그램입니다.',
+    period: '2024.03.01 ~ 2024.11.30',
+    target: '지역주민, 관심 있는 시민',
+    capacity: '40명',
+    image: '/images/education1.jpg',
+  },
+  {
+    id: 2,
+    title: '환경 보전 교육',
+    description: '지역 환경 보전과 지속가능한 발전에 대한 교육입니다.',
+    period: '2024.04.01 ~ 2024.10.31',
+    target: '환경 관심자, 학생',
+    capacity: '30명',
+    image: '/images/education2.jpg',
+  },
+];

--- a/src/components/business/data/index.ts
+++ b/src/components/business/data/index.ts
@@ -1,0 +1,16 @@
+// Urban Regeneration Data
+export {
+  academyCards,
+  educationCards,
+  type AcademyCard,
+  type EducationCard,
+} from './urbanRegenerationData';
+
+// Events Education Data
+export { eventCards, type EventCard } from './eventsEducationData';
+
+// Cafe27b Data
+export * from './cafe27bData';
+
+// Local Activation Data
+export * from './localActivationData';

--- a/src/components/business/data/localActivationData.ts
+++ b/src/components/business/data/localActivationData.ts
@@ -1,0 +1,76 @@
+export interface EventImage {
+  id: number;
+  name: string;
+  src: string;
+  alt: string;
+}
+
+export interface CommunityProject {
+  id: number;
+  title: string;
+  description: string;
+  icon: string;
+}
+
+export interface EducationMethod {
+  id: number;
+  title: string;
+  description: string;
+}
+
+export const eventImages: EventImage[] = [
+  {
+    id: 1,
+    name: '이미지1',
+    src: '/images/local/event1.jpg',
+    alt: '지역 공동체 행사 이미지 1',
+  },
+  {
+    id: 2,
+    name: '이미지2',
+    src: '/images/local/event2.jpg',
+    alt: '지역 공동체 행사 이미지 2',
+  },
+  {
+    id: 3,
+    name: '이미지3',
+    src: '/images/local/event3.jpg',
+    alt: '지역 공동체 행사 이미지 3',
+  },
+];
+
+export const communityProjects: CommunityProject[] = [
+  {
+    id: 1,
+    title: '지역사랑 상품권',
+    description: '지역 경제 활성화를 위한 상품권 발행 및 사용 촉진',
+    icon: '/images/local/icon1.svg',
+  },
+  {
+    id: 2,
+    title: '지역사랑 상품권',
+    description: '지역 경제 활성화를 위한 상품권 발행 및 사용 촉진',
+    icon: '/images/local/icon2.svg',
+  },
+];
+
+export const educationMethods: EducationMethod[] = [
+  {
+    id: 1,
+    title: '우선순위 설정',
+    description: '중요한 작업을 먼저 처리함으로써 효율성을 높일 수 있습니다.',
+  },
+  {
+    id: 2,
+    title: '시간 블록 기법',
+    description: '작업에 특정 시간을 할당하여 집중력을 유지할 수 있습니다.',
+  },
+  {
+    id: 3,
+    title: 'Pomodoro 기법',
+    description: '25분 집중 작업 후 5분 휴식을 반복하여 집중력과 피로를 관리할 수 있습니다.',
+  },
+];
+
+export const educationSummary =
+  '이러한 방법들을 통해 디지털 환경에서 효과적으로 시간을 관리할 수 있습니다.';

--- a/src/components/business/data/urbanRegenerationData.ts
+++ b/src/components/business/data/urbanRegenerationData.ts
@@ -1,0 +1,71 @@
+export interface AcademyCard {
+  id: number;
+  title: string;
+  description: string;
+  period: string;
+  target: string;
+  capacity: string;
+}
+
+export interface EducationCard {
+  id: number;
+  title: string;
+  description: string;
+  period: string;
+  target: string;
+  capacity: string;
+}
+
+export const academyCards: AcademyCard[] = [
+  {
+    id: 1,
+    title: '카페 운영 실무 아카데미',
+    description: '카페 운영에 필요한 실무 지식과 기술을 습득할 수 있는 교육 프로그램입니다.',
+    period: '2024.03.01 ~ 2024.05.31',
+    target: '카페 창업 희망자, 카페 운영자',
+    capacity: '20명',
+  },
+  // {
+  //   id: 2,
+  //   title: '바리스타 전문 과정',
+  //   description: '전문 바리스타가 되기 위한 커피 제조 기술과 이론을 배우는 과정입니다.',
+  //   period: '2024.04.01 ~ 2024.06.30',
+  //   target: '바리스타 지망생, 카페 직원',
+  //   capacity: '15명',
+  // },
+];
+
+export const educationCards: EducationCard[] = [
+  {
+    id: 1,
+    title: '조합 역량 강화 교육',
+    description: '조합원들의 역량을 강화하고 협동조합 운영에 필요한 지식을 제공합니다.',
+    period: '2024.02.01 ~ 2024.12.31',
+    target: '조합원, 지역주민',
+    capacity: '50명',
+  },
+  {
+    id: 2,
+    title: '디지털 리터러시 교육',
+    description: '디지털 시대에 필요한 기본적인 컴퓨터 활용 능력을 기르는 교육입니다.',
+    period: '2024.03.15 ~ 2024.08.15',
+    target: '중장년층, 디지털 소외계층',
+    capacity: '30명',
+  },
+  {
+    id: 3,
+    title: '조합 역량 강화 교육',
+    description: '조합원들의 역량을 강화하고 협동조합 운영에 필요한 지식을 제공합니다.',
+    period: '2024.02.01 ~ 2024.12.31',
+    target: '조합원, 지역주민',
+    capacity: '50명',
+  },
+  {
+    id: 4,
+    title: '디지털 리터러시 교육',
+    description: '디지털 시대에 필요한 기본적인 컴퓨터 활용 능력을 기르는 교육입니다.',
+    period: '2024.03.15 ~ 2024.08.15',
+    target: '중장년층, 디지털 소외계층',
+    capacity: '30명',
+  },
+];

--- a/src/components/combination/Greeting.tsx
+++ b/src/components/combination/Greeting.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
+import type { GreetingData } from './data';
+import { greetingData as defaultData } from './data';
 
-const Greeting: React.FC = () => {
+interface GreetingProps {
+  data?: GreetingData;
+}
+
+const Greeting: React.FC<GreetingProps> = ({ data = defaultData }) => {
   return (
     <div className="py-8 px-4">
       <div className="text-center mb-16">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">인사말</h2>
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">{data.title}</h2>
         <div className="w-16 h-1 bg-black mx-auto mb-6"></div>
       </div>
 
@@ -12,34 +18,31 @@ const Greeting: React.FC = () => {
         <div className="grid md:grid-cols-2 gap-8 items-center">
           {/* 이미지 영역 */}
           <div className="bg-gray-200 rounded-lg flex items-center justify-center aspect-[620/600] w-full max-w-[620px] mx-auto">
-            <span className="text-gray-500 text-lg">이미지</span>
+            <span className="text-gray-500 text-lg">{data.image.alt}</span>
           </div>
 
           {/* 텍스트 영역 */}
           <div className="space-y-8 sm:space-y-12">
             <div className="space-y-1">
-              <p className="text-lg sm:text-xl">안녕하세요.</p>
-              <p className="text-lg sm:text-xl">화전마을 사회적협동조합입니다.</p>
+              <p className="text-lg sm:text-xl">{data.greeting.line1}</p>
+              <p className="text-lg sm:text-xl">{data.greeting.line2}</p>
             </div>
 
             <div className="space-y-6 sm:space-y-8 text-sm sm:text-base text-gray-700 leading-relaxed">
-              <p>
-                세계 최초의 상업 우주 관광이 시작되면서 대기자 명단이 급속도로 늘어나고 있습니다.
-                지구 궤도를 일주하는 일주일간의 여행을 통해 관광객들은 우주의 아름다움과 경이로움을
-                직접 체험할 수 있게 되었습니다.
-              </p>
-              <p>
-                우주 관광 산업은 부유층의 여가 활동을 넘어 일반 대중에게까지 확산될 가능성이
-                높아지고 있으며, 전문가들은 이는 새로운 관광 산업의 핵심이 될 것이며 우주 과학 기술
-                발전에도 기여할 것으로 보고 있습니다.
-              </p>
+              {data.content.map((paragraph) => (
+                <p key={paragraph.id}>{paragraph.text}</p>
+              ))}
             </div>
 
             {/* 서명 영역 */}
             <div className="flex items-center space-x-4 mt-8 sm:mt-12">
-              <span className="text-gray-600 font-semibold text-lg sm:text-xl">대표자</span>
+              <span className="text-gray-600 font-semibold text-lg sm:text-xl">
+                {data.signature.title}
+              </span>
               <div className="flex items-center space-x-2">
-                <span className="text-gray-800 font-semibold text-lg sm:text-xl">홍길동</span>
+                <span className="text-gray-800 font-semibold text-lg sm:text-xl">
+                  {data.signature.name}
+                </span>
                 <div className="w-6 h-6 bg-red-500 rounded-sm"></div>
               </div>
             </div>

--- a/src/components/combination/History.tsx
+++ b/src/components/combination/History.tsx
@@ -1,70 +1,19 @@
 import React from 'react';
 import { TimelineZigzag } from '.';
 import TimelineImg from '@/assets/timeline.jpg';
+import type { HistoryItem } from './data';
+import { historyData as defaultHistoryData } from './data';
 
-const History: React.FC = () => {
-  const historyData = [
-    // {
-    //   year: 2028,
-    //   bullets: [
-    //     '미래 비전 실현을 위한 중장기 계획 수립',
-    //     '지역 사회적 경제 생태계 완성',
-    //     '화전마을 브랜드 가치 향상',
-    //   ],
-    // },
-    // {
-    //   year: 2027,
-    //   bullets: [
-    //     '미래 비전 실현을 위한 중장기 계획 수립',
-    //     '지역 사회적 경제 생태계 완성',
-    //     '화전마을 브랜드 가치 향상',
-    //   ],
-    // },
-    // {
-    //   year: 2026,
-    //   bullets: [
-    //     '미래 비전 실현을 위한 중장기 계획 수립',
-    //     '지역 사회적 경제 생태계 완성',
-    //     '화전마을 브랜드 가치 향상',
-    //   ],
-    // },
-    {
-      year: 2025,
-      bullets: [
-        '미래 비전 실현을 위한 중장기 계획 수립',
-        '지역 사회적 경제 생태계 완성',
-        '화전마을 브랜드 가치 향상',
-      ],
-    },
-    {
-      year: 2024,
-      bullets: [
-        '조합원 확대 및 조직 강화',
-        '지속가능한 지역 순환 생태계 구축',
-        '마을 공동체 네트워크 확장',
-      ],
-    },
-    {
-      year: 2023,
-      bullets: [
-        '행사 기획 및 교육 체험 사업 확장',
-        '지역 활성화 사업 본격 추진',
-        '주민 참여 프로그램 다각화',
-      ],
-    },
-    {
-      year: 2022,
-      bullets: [
-        '화전마을사회적협동조합 정식 설립',
-        '도시재생 거점공간 운영 사업 시작',
-        '카페27b 오픈',
-      ],
-    },
-    {
-      year: 2021,
-      bullets: ['화전마을사회적협동조합 설립 준비', '지역 주민 의견 수렴 및 조합 설립 계획 수립'],
-    },
-  ];
+interface HistoryProps {
+  historyData?: HistoryItem[];
+}
+
+const History: React.FC<HistoryProps> = ({ historyData = defaultHistoryData }) => {
+  // 데이터를 TimelineZigzag가 기대하는 형식으로 변환
+  const timelineData = historyData.map((item) => ({
+    year: parseInt(item.year),
+    bullets: [item.description],
+  }));
 
   return (
     <div className="relative min-h-screen">
@@ -89,7 +38,7 @@ const History: React.FC = () => {
           </div>
 
           {/* 가로 타임라인 */}
-          <TimelineZigzag items={historyData} />
+          <TimelineZigzag items={timelineData} />
         </div>
       </div>
     </div>

--- a/src/components/combination/HwajeonStory.tsx
+++ b/src/components/combination/HwajeonStory.tsx
@@ -1,18 +1,30 @@
+import type { Card as CardType, StoryImage } from './data';
+import {
+  cards as defaultCards,
+  storyImages as defaultStoryImages,
+  mainStoryImage as defaultMainStoryImage,
+} from './data';
+
 interface CardProps {
   title: string;
-  description: string;
+  description?: string;
   type: 'gradient' | 'gray' | 'image';
-  gradientFrom?: string;
-  gradientTo?: string;
+  gradient?: string;
 }
 
-function Card({ title, description, type, gradientFrom, gradientTo }: CardProps) {
+interface HwajeonStoryProps {
+  cards?: CardType[];
+  storyImages?: StoryImage[];
+  mainStoryImage?: { src: string; alt: string };
+}
+
+function Card({ title, description, type, gradient }: CardProps) {
   const baseClasses =
     'p-4 sm:p-6 rounded-lg w-full max-w-[280px] sm:max-w-[330px] xl:max-w-[285px] aspect-square mx-auto lg:mx-0';
 
   if (type === 'gradient') {
     return (
-      <div className={`bg-gradient-to-br ${gradientFrom} ${gradientTo} text-white ${baseClasses}`}>
+      <div className={`bg-gradient-to-br ${gradient} text-white ${baseClasses}`}>
         <h4 className="text-xl sm:text-2xl font-bold mb-2 sm:mb-3">{title}</h4>
         <p className="text-blue-100 text-sm sm:text-base">{description}</p>
       </div>
@@ -48,34 +60,11 @@ function Card({ title, description, type, gradientFrom, gradientTo }: CardProps)
   return null;
 }
 
-export default function HwajeonStory() {
-  const cards = [
-    {
-      title: '잇다',
-      description: '주민과 공간, 세대와 세대를 연결하는 마을',
-      type: 'gradient' as const,
-      gradientFrom: 'from-blue-600',
-      gradientTo: 'to-purple-700',
-    },
-    {
-      title: '키워드',
-      description: '간단한 설명',
-      type: 'gradient' as const,
-      gradientFrom: 'from-purple-600',
-      gradientTo: 'to-blue-700',
-    },
-    {
-      title: '키워드',
-      description: '간단한 설명',
-      type: 'gradient' as const,
-      gradientFrom: 'from-purple-600',
-      gradientTo: 'to-blue-700',
-    },
-    { title: '키워드', description: '간단한 설명', type: 'gray' as const },
-    { title: '키워드', description: '간단한 설명', type: 'gray' as const },
-    { title: '키워드', description: '간단한 설명', type: 'image' as const },
-  ];
-
+export default function HwajeonStory({
+  cards = defaultCards,
+  storyImages = defaultStoryImages,
+  mainStoryImage = defaultMainStoryImage,
+}: HwajeonStoryProps) {
   return (
     <div className="mx-auto py-8">
       {/* 화전 이야기 섹션 */}
@@ -87,23 +76,27 @@ export default function HwajeonStory() {
         <div className="max-w-5xl mx-auto mb-8">
           {/* 큰 화면에서는 그리드 */}
           <div className="hidden md:grid md:grid-cols-2 gap-6">
-            <div className="bg-gray-200 h-56 lg:h-64 rounded-lg flex items-center justify-center">
-              <span className="text-gray-500 text-lg">이미지</span>
-            </div>
-            <div className="bg-gray-200 h-56 lg:h-64 rounded-lg flex items-center justify-center">
-              <span className="text-gray-500 text-lg">이미지</span>
-            </div>
+            {storyImages.slice(0, 2).map((image, index) => (
+              <div
+                key={index}
+                className="bg-gray-200 h-56 lg:h-64 rounded-lg flex items-center justify-center"
+              >
+                <span className="text-gray-500 text-lg">{image.alt}</span>
+              </div>
+            ))}
           </div>
 
           {/* 작은 화면에서는 가로 스크롤 */}
           <div className="md:hidden overflow-x-auto">
             <div className="flex gap-6 min-w-max px-4">
-              <div className="bg-gray-200 h-48 w-80 rounded-lg flex items-center justify-center flex-shrink-0">
-                <span className="text-gray-500 text-lg">이미지</span>
-              </div>
-              <div className="bg-gray-200 h-48 w-80 rounded-lg flex items-center justify-center flex-shrink-0">
-                <span className="text-gray-500 text-lg">이미지</span>
-              </div>
+              {storyImages.map((image, index) => (
+                <div
+                  key={index}
+                  className="bg-gray-200 h-48 w-80 rounded-lg flex items-center justify-center flex-shrink-0"
+                >
+                  <span className="text-gray-500 text-lg">{image.alt}</span>
+                </div>
+              ))}
             </div>
           </div>
         </div>
@@ -129,7 +122,7 @@ export default function HwajeonStory() {
         </div>
 
         <div className="bg-gray-200 w-full h-48 sm:h-64 lg:h-80 rounded-lg flex items-center justify-center mb-8">
-          <span className="text-gray-500 text-lg">이미지</span>
+          <span className="text-gray-500 text-lg">{mainStoryImage.alt}</span>
         </div>
 
         <div className="max-w-5xl mx-auto px-4">

--- a/src/components/combination/MissionVision.tsx
+++ b/src/components/combination/MissionVision.tsx
@@ -1,32 +1,34 @@
 import React from 'react';
+import type { MissionVisionData } from './data';
+import { missionVisionData as defaultData } from './data';
 
-const MissionVision: React.FC = () => {
+interface MissionVisionProps {
+  data?: MissionVisionData;
+}
+
+const MissionVision: React.FC<MissionVisionProps> = ({ data = defaultData }) => {
   return (
     <div className="py-8 px-4">
       <div className="text-center mb-16">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">미션 & 비전</h2>
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-4">{data.header.title}</h2>
         <div className="w-16 h-1 bg-black mx-auto mb-6"></div>
       </div>
       {/* 헤더 섹션 */}
       <div className="text-center mb-12 max-w-5xl mx-auto">
-        <h2 className="text-lg sm:text-xl font-normal mb-1">화전마을사회적협동조합은</h2>
+        <h2 className="text-lg sm:text-xl font-normal mb-1">{data.header.subtitle}</h2>
         <p className="text-sm sm:text-base text-gray-600 leading-relaxed max-w-4xl mx-auto">
-          지역 주민이 주체가 되어 마을의 삶을 스스로 기획하고 실현하는 플랫폼을 구축하기 위해,
-          <br />
-          자립적인 공동체 기반 조성과 지속가능한 지역 순환 생태계를 만들어가고 있습니다.
+          {data.header.description}
         </p>
       </div>
 
       {/* 미션 섹션 */}
       <div className="mb-16 max-w-5xl mx-auto">
         <div className="mb-6">
-          <h3 className="text-lg sm:text-xl font-bold mb-2">미션</h3>
-          <p className="text-sm sm:text-base text-gray-500">소제목</p>
+          <h3 className="text-lg sm:text-xl font-bold mb-2">{data.mission.title}</h3>
+          <p className="text-sm sm:text-base text-gray-500">{data.mission.subtitle}</p>
         </div>
         <div className="bg-gray-100 p-6 sm:p-8 rounded-lg">
-          <p className="text-sm sm:text-base text-gray-700 font-medium">
-            모든 사용자가 디지털 환경에서 평등한 기회를 누릴 수 있도록 지원
-          </p>
+          <p className="text-sm sm:text-base text-gray-700 font-medium">{data.mission.content}</p>
         </div>
       </div>
 
@@ -35,28 +37,13 @@ const MissionVision: React.FC = () => {
         <div className="px-4">
           <div className="max-w-5xl mx-auto">
             <div className="mb-8">
-              <h3 className="text-lg sm:text-xl font-bold mb-2">비전</h3>
-              <p className="text-sm sm:text-base text-gray-500">소제목</p>
+              <h3 className="text-lg sm:text-xl font-bold mb-2">{data.vision.title}</h3>
+              <p className="text-sm sm:text-base text-gray-500">{data.vision.subtitle}</p>
             </div>
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
-              <div className="bg-gray-100 p-4 sm:p-6 rounded-lg text-center">
-                <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gray-300 rounded-full mx-auto mb-4 flex items-center justify-center">
-                  <span className="text-gray-500 text-xs sm:text-sm">아이콘</span>
-                </div>
-                <p className="text-sm sm:text-base text-gray-700 font-medium">비전1</p>
-              </div>
-              <div className="bg-gray-100 p-4 sm:p-6 rounded-lg text-center">
-                <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gray-300 rounded-full mx-auto mb-4 flex items-center justify-center">
-                  <span className="text-gray-500 text-xs sm:text-sm">아이콘</span>
-                </div>
-                <p className="text-sm sm:text-base text-gray-700 font-medium">비전2</p>
-              </div>
-              <div className="bg-gray-100 p-4 sm:p-6 rounded-lg text-center sm:col-span-2 lg:col-span-1">
-                <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gray-300 rounded-full mx-auto mb-4 flex items-center justify-center">
-                  <span className="text-gray-500 text-xs sm:text-sm">아이콘</span>
-                </div>
-                <p className="text-sm sm:text-base text-gray-700 font-medium">비전3</p>
-              </div>
+            <div className="bg-gray-100 p-6 sm:p-8 rounded-lg">
+              <p className="text-sm sm:text-base text-gray-700 font-medium">
+                {data.vision.content}
+              </p>
             </div>
           </div>
         </div>
@@ -65,38 +52,19 @@ const MissionVision: React.FC = () => {
       {/* 핵심가치 섹션 */}
       <div className="max-w-5xl mx-auto mt-16">
         <div className="mb-8">
-          <h3 className="text-lg sm:text-xl font-bold mb-2">핵심가치</h3>
-          <p className="text-sm sm:text-base text-gray-500">소제목</p>
+          <h3 className="text-lg sm:text-xl font-bold mb-2">{data.values.title}</h3>
+          <p className="text-sm sm:text-base text-gray-500">{data.values.subtitle}</p>
         </div>
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 max-w-6xl mx-auto">
-          <div className="bg-gray-100 p-4 sm:p-6 rounded-lg text-center">
-            <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gray-300 rounded-lg mx-auto mb-4 flex items-center justify-center">
-              <span className="text-gray-500 text-xs sm:text-sm">이미지</span>
+          {data.values.items.map((item) => (
+            <div key={item.id} className="bg-gray-100 p-4 sm:p-6 rounded-lg text-center">
+              <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gray-300 rounded-lg mx-auto mb-4 flex items-center justify-center">
+                <span className="text-gray-500 text-xs sm:text-sm">이미지</span>
+              </div>
+              <p className="text-sm sm:text-base text-gray-700 font-medium mb-2">{item.title}</p>
+              <p className="text-xs sm:text-sm text-gray-600">{item.description}</p>
             </div>
-            <p className="text-sm sm:text-base text-gray-700 font-medium mb-2">키워드</p>
-            <p className="text-xs sm:text-sm text-gray-600">설명글</p>
-          </div>
-          <div className="bg-gray-100 p-4 sm:p-6 rounded-lg text-center">
-            <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gray-300 rounded-lg mx-auto mb-4 flex items-center justify-center">
-              <span className="text-gray-500 text-xs sm:text-sm">이미지</span>
-            </div>
-            <p className="text-sm sm:text-base text-gray-700 font-medium mb-2">키워드</p>
-            <p className="text-xs sm:text-sm text-gray-600">설명글</p>
-          </div>
-          <div className="bg-gray-100 p-4 sm:p-6 rounded-lg text-center">
-            <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gray-300 rounded-lg mx-auto mb-4 flex items-center justify-center">
-              <span className="text-gray-500 text-xs sm:text-sm">이미지</span>
-            </div>
-            <p className="text-sm sm:text-base text-gray-700 font-medium mb-2">키워드</p>
-            <p className="text-xs sm:text-sm text-gray-600">설명글</p>
-          </div>
-          <div className="bg-gray-100 p-4 sm:p-6 rounded-lg text-center">
-            <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gray-300 rounded-lg mx-auto mb-4 flex items-center justify-center">
-              <span className="text-gray-500 text-xs sm:text-sm">이미지</span>
-            </div>
-            <p className="text-sm sm:text-base text-gray-700 font-medium mb-2">키워드</p>
-            <p className="text-xs sm:text-sm text-gray-600">설명글</p>
-          </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/combination/OrganizationDetails.tsx
+++ b/src/components/combination/OrganizationDetails.tsx
@@ -1,56 +1,13 @@
 import { useState } from 'react';
 import { ChevronUp, ChevronDown } from 'lucide-react';
-// import { cn } from '@/lib/utils';
+import type { Team } from './data';
+import { teams as defaultTeams } from './data';
 
-interface Team {
-  name: string;
-  members?: Array<{
-    position: string;
-    name: string;
-    duties: string;
-  }>;
+interface OrganizationDetailsProps {
+  teams?: Team[];
 }
 
-const teams: Team[] = [
-  {
-    name: '이사회 임원',
-    members: [
-      { position: '조합장', name: '홍길동', duties: '조합 대표자, 전체 운영 총괄' },
-      { position: '대표이사', name: '홍길동', duties: '정책/사업 방향 논의 및 의결' },
-      { position: '이사', name: '홍길동', duties: '교육 및 주민참여 프로그램 검토' },
-    ],
-  },
-  {
-    name: '기획행정팀',
-    members: [
-      { position: '팀장', name: '김철수', duties: '기획 및 행정 업무 총괄' },
-      { position: '주무', name: '이영희', duties: '일반 행정 업무' },
-    ],
-  },
-  {
-    name: '지역사회팀',
-    members: [
-      { position: '팀장', name: '박민수', duties: '지역사회 연계 업무' },
-      { position: '주무', name: '정수진', duties: '주민 참여 프로그램 운영' },
-    ],
-  },
-  {
-    name: '교육문화팀',
-    members: [
-      { position: '팀장', name: '최현우', duties: '교육 프로그램 기획' },
-      { position: '주무', name: '한지은', duties: '문화 행사 기획' },
-    ],
-  },
-  {
-    name: '카페27b 운영팀',
-    members: [
-      { position: '팀장', name: '강동훈', duties: '카페 운영 총괄' },
-      { position: '주무', name: '윤서연', duties: '일반 운영 업무' },
-    ],
-  },
-];
-
-export default function OrganizationDetails() {
+export default function OrganizationDetails({ teams = defaultTeams }: OrganizationDetailsProps) {
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
 
   const toggleSection = (sectionId: string) => {

--- a/src/components/combination/data/greetingData.ts
+++ b/src/components/combination/data/greetingData.ts
@@ -1,0 +1,43 @@
+export interface GreetingData {
+  title: string;
+  image: {
+    alt: string;
+  };
+  greeting: {
+    line1: string;
+    line2: string;
+  };
+  content: Array<{
+    id: number;
+    text: string;
+  }>;
+  signature: {
+    title: string;
+    name: string;
+  };
+}
+
+export const greetingData: GreetingData = {
+  title: '인사말',
+  image: {
+    alt: '대표자 이미지',
+  },
+  greeting: {
+    line1: '안녕하세요.',
+    line2: '화전마을 사회적협동조합입니다.',
+  },
+  content: [
+    {
+      id: 1,
+      text: '세계 최초의 상업 우주 관광이 시작되면서 대기자 명단이 급속도로 늘어나고 있습니다. 지구 궤도를 일주하는 일주일간의 여행을 통해 관광객들은 우주의 아름다움과 경이로움을 직접 체험할 수 있게 되었습니다.',
+    },
+    {
+      id: 2,
+      text: '우주 관광 산업은 부유층의 여가 활동을 넘어 일반 대중에게까지 확산될 가능성이 높아지고 있으며, 전문가들은 이는 새로운 관광 산업의 핵심이 될 것이며 우주 과학 기술 발전에도 기여할 것으로 보고 있습니다.',
+    },
+  ],
+  signature: {
+    title: '대표자',
+    name: '홍길동',
+  },
+};

--- a/src/components/combination/data/historyData.ts
+++ b/src/components/combination/data/historyData.ts
@@ -1,0 +1,39 @@
+export interface HistoryItem {
+  id: number;
+  year: string;
+  title: string;
+  description: string;
+}
+
+export const historyData: HistoryItem[] = [
+  {
+    id: 1,
+    year: '2020',
+    title: '화전 협동조합 설립',
+    description: '지역 주민들의 자발적인 참여로 화전 협동조합이 설립되었습니다.',
+  },
+  {
+    id: 2,
+    year: '2021',
+    title: '카페27b 오픈',
+    description: '지역 상생을 위한 카페27b가 정식 오픈되었습니다.',
+  },
+  {
+    id: 3,
+    year: '2022',
+    title: '도시재생 사업 시작',
+    description: '화전 지역의 도시재생을 위한 다양한 사업이 시작되었습니다.',
+  },
+  {
+    id: 4,
+    year: '2023',
+    title: '지역 활성화 사업 확장',
+    description: '지역 경제 활성화를 위한 다양한 프로그램이 확장되었습니다.',
+  },
+  {
+    id: 5,
+    year: '2024',
+    title: '디지털 전환',
+    description: '디지털 기술을 활용한 새로운 서비스와 프로그램을 도입했습니다.',
+  },
+];

--- a/src/components/combination/data/hwajeonStoryData.ts
+++ b/src/components/combination/data/hwajeonStoryData.ts
@@ -1,0 +1,75 @@
+export interface Card {
+  id: number;
+  type: 'gradient' | 'gray' | 'image';
+  title: string;
+  description?: string;
+  image?: string;
+  gradient?: string;
+}
+
+export interface StoryImage {
+  id: number;
+  src: string;
+  alt: string;
+}
+
+export const cards: Card[] = [
+  {
+    id: 1,
+    type: 'gradient',
+    title: '화전의 정체성',
+    description: '화전만의 독특한 정체성과 가치',
+    gradient: 'from-blue-500 to-purple-600',
+  },
+  {
+    id: 2,
+    type: 'gray',
+    title: '지역 공동체',
+    description: '함께 만들어가는 지역 공동체',
+  },
+  {
+    id: 3,
+    type: 'image',
+    title: '협동조합',
+    description: '상생과 협동의 가치',
+    image: '/images/story/coop.jpg',
+  },
+  {
+    id: 4,
+    type: 'gradient',
+    title: '지속가능성',
+    description: '지속가능한 발전과 미래',
+    gradient: 'from-green-500 to-blue-600',
+  },
+  {
+    id: 5,
+    type: 'gray',
+    title: '혁신',
+    description: '새로운 도전과 혁신',
+  },
+  {
+    id: 6,
+    type: 'image',
+    title: '희망',
+    description: '더 나은 미래를 향한 희망',
+    image: '/images/story/hope.jpg',
+  },
+];
+
+export const storyImages: StoryImage[] = [
+  {
+    id: 1,
+    src: '/images/story/image1.jpg',
+    alt: '화전 마을의 모습',
+  },
+  {
+    id: 2,
+    src: '/images/story/image2.jpg',
+    alt: '지역 주민들의 활동',
+  },
+];
+
+export const mainStoryImage = {
+  src: '/images/story/main.jpg',
+  alt: '화전 마을의 변화와 흐름',
+};

--- a/src/components/combination/data/index.ts
+++ b/src/components/combination/data/index.ts
@@ -1,0 +1,17 @@
+// History Data
+export * from './historyData';
+
+// Organization Data
+export * from './organizationData';
+
+// Hwajeon Story Data
+export * from './hwajeonStoryData';
+
+// Mission Vision Data
+export * from './missionVisionData';
+
+// Greeting Data
+export * from './greetingData';
+
+// Organization Chart Data
+export * from './organizationChartData';

--- a/src/components/combination/data/missionVisionData.ts
+++ b/src/components/combination/data/missionVisionData.ts
@@ -1,0 +1,71 @@
+export interface MissionVisionData {
+  header: {
+    title: string;
+    subtitle: string;
+    description: string;
+  };
+  mission: {
+    title: string;
+    subtitle: string;
+    content: string;
+  };
+  vision: {
+    title: string;
+    subtitle: string;
+    content: string;
+  };
+  values: {
+    title: string;
+    subtitle: string;
+    items: Array<{
+      id: number;
+      title: string;
+      description: string;
+    }>;
+  };
+}
+
+export const missionVisionData: MissionVisionData = {
+  header: {
+    title: '미션 & 비전',
+    subtitle: '화전마을사회적협동조합은',
+    description:
+      '지역 주민이 주체가 되어 마을의 삶을 스스로 기획하고 실현하는 플랫폼을 구축하기 위해, 자립적인 공동체 기반 조성과 지속가능한 지역 순환 생태계를 만들어가고 있습니다.',
+  },
+  mission: {
+    title: '미션',
+    subtitle: '소제목',
+    content: '모든 사용자가 디지털 환경에서 평등한 기회를 누릴 수 있도록 지원',
+  },
+  vision: {
+    title: '비전',
+    subtitle: '소제목',
+    content: '디지털 포용성을 통해 모든 사람이 연결되고 성장할 수 있는 사회 구현',
+  },
+  values: {
+    title: '핵심 가치',
+    subtitle: '소제목',
+    items: [
+      {
+        id: 1,
+        title: '협동',
+        description: '함께 일하고 함께 성장하는 협동의 정신',
+      },
+      {
+        id: 2,
+        title: '상생',
+        description: '모든 구성원이 함께 번영하는 상생의 가치',
+      },
+      {
+        id: 3,
+        title: '지속가능성',
+        description: '미래 세대를 위한 지속가능한 발전',
+      },
+      {
+        id: 4,
+        title: '혁신',
+        description: '새로운 아이디어와 방법으로 문제를 해결',
+      },
+    ],
+  },
+};

--- a/src/components/combination/data/organizationChartData.ts
+++ b/src/components/combination/data/organizationChartData.ts
@@ -1,0 +1,28 @@
+export interface OrganizationNode {
+  label: string;
+  variant?: 'filled' | 'outline' | 'primary';
+}
+
+export interface OrganizationChartData {
+  top: OrganizationNode;
+  second: [OrganizationNode, OrganizationNode, OrganizationNode];
+  teams: [OrganizationNode, OrganizationNode, OrganizationNode, OrganizationNode];
+}
+
+export const organizationChartData: OrganizationChartData = {
+  top: {
+    label: '조합장',
+    variant: 'primary',
+  },
+  second: [
+    { label: '이사회', variant: 'filled' },
+    { label: '사무국', variant: 'filled' },
+    { label: '감사', variant: 'filled' },
+  ],
+  teams: [
+    { label: '기획행정팀', variant: 'outline' },
+    { label: '지역사회팀', variant: 'outline' },
+    { label: '교육문화팀', variant: 'outline' },
+    { label: '카페27b운영팀', variant: 'outline' },
+  ],
+};

--- a/src/components/combination/data/organizationData.ts
+++ b/src/components/combination/data/organizationData.ts
@@ -1,0 +1,188 @@
+export interface BoardMember {
+  id: number;
+  name: string;
+  position: string;
+  department: string;
+}
+
+export interface TeamMember {
+  id: number;
+  name: string;
+  position: string;
+  department: string;
+  duties: string;
+}
+
+export interface Team {
+  id: number;
+  name: string;
+  description: string;
+  members: TeamMember[];
+}
+
+export const boardMembers: BoardMember[] = [
+  {
+    id: 1,
+    name: '김화전',
+    position: '이사장',
+    department: '이사회',
+  },
+  {
+    id: 2,
+    name: '이지역',
+    position: '이사',
+    department: '이사회',
+  },
+  {
+    id: 3,
+    name: '박협동',
+    position: '이사',
+    department: '이사회',
+  },
+  {
+    id: 4,
+    name: '최상생',
+    position: '이사',
+    department: '이사회',
+  },
+];
+
+const boardMembersWithDuties: TeamMember[] = boardMembers.map((member) => ({
+  ...member,
+  duties: '조합의 운영 방향 결정 및 정책 수립',
+}));
+
+export const teams: Team[] = [
+  {
+    id: 1,
+    name: '이사회 임원',
+    description: '조합의 최고 의결기구로 조합의 운영 방향을 결정합니다.',
+    members: boardMembersWithDuties,
+  },
+  {
+    id: 2,
+    name: '감사',
+    description: '조합의 회계와 업무를 감사합니다.',
+    members: [
+      {
+        id: 1,
+        name: '정감사',
+        position: '감사',
+        department: '감사',
+        duties: '조합의 회계와 업무 감사',
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: '사무국',
+    description: '조합의 일상적인 업무를 처리합니다.',
+    members: [
+      {
+        id: 1,
+        name: '한사무',
+        position: '사무국장',
+        department: '사무국',
+        duties: '사무국 업무 총괄 및 관리',
+      },
+      {
+        id: 2,
+        name: '윤직원',
+        position: '주무',
+        department: '사무국',
+        duties: '일반 행정 업무 처리',
+      },
+      {
+        id: 3,
+        name: '강직원',
+        position: '주무',
+        department: '사무국',
+        duties: '일반 행정 업무 처리',
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: '기획행정팀',
+    description: '조합의 기획 및 행정 업무를 담당합니다.',
+    members: [
+      {
+        id: 1,
+        name: '김기획',
+        position: '팀장',
+        department: '기획행정팀',
+        duties: '기획 및 행정 업무 총괄',
+      },
+      {
+        id: 2,
+        name: '이행정',
+        position: '주무',
+        department: '기획행정팀',
+        duties: '일반 행정 업무',
+      },
+    ],
+  },
+  {
+    id: 5,
+    name: '지역사회팀',
+    description: '지역사회 연계 업무를 담당합니다.',
+    members: [
+      {
+        id: 1,
+        name: '박지역',
+        position: '팀장',
+        department: '지역사회팀',
+        duties: '지역사회 연계 업무',
+      },
+      {
+        id: 2,
+        name: '정주민',
+        position: '주무',
+        department: '지역사회팀',
+        duties: '주민 참여 프로그램 운영',
+      },
+    ],
+  },
+  {
+    id: 6,
+    name: '교육문화팀',
+    description: '교육 및 문화 프로그램을 담당합니다.',
+    members: [
+      {
+        id: 1,
+        name: '최교육',
+        position: '팀장',
+        department: '교육문화팀',
+        duties: '교육 프로그램 기획',
+      },
+      {
+        id: 2,
+        name: '한문화',
+        position: '주무',
+        department: '교육문화팀',
+        duties: '문화 행사 기획',
+      },
+    ],
+  },
+  {
+    id: 7,
+    name: '카페27b운영팀',
+    description: '카페27b 운영을 담당합니다.',
+    members: [
+      {
+        id: 1,
+        name: '강카페',
+        position: '팀장',
+        department: '카페27b운영팀',
+        duties: '카페 운영 총괄',
+      },
+      {
+        id: 2,
+        name: '윤운영',
+        position: '주무',
+        department: '카페27b운영팀',
+        duties: '일반 운영 업무',
+      },
+    ],
+  },
+];

--- a/src/pages/member/Business.tsx
+++ b/src/pages/member/Business.tsx
@@ -6,6 +6,20 @@ import {
   Cafe27b,
   LocalActivation,
 } from '@/components/business';
+import {
+  mainImages,
+  menuItems,
+  productItems,
+  cateringServices,
+  mobileCafeServices,
+  eventImages,
+  communityProjects,
+  educationMethods,
+  educationSummary,
+  academyCards,
+  educationCards,
+  eventCards,
+} from '@/components/business/data';
 
 function Business() {
   const tabs: TabItem[] = [
@@ -20,13 +34,28 @@ function Business() {
   const renderTabContent = () => {
     switch (activeTab) {
       case 'urban-regeneration':
-        return <UrbanRegenerationHub />;
+        return <UrbanRegenerationHub academyCards={academyCards} educationCards={educationCards} />;
       case 'events-education':
-        return <EventsEducation />;
+        return <EventsEducation eventCards={eventCards} />;
       case 'cafe27b':
-        return <Cafe27b />;
+        return (
+          <Cafe27b
+            mainImages={mainImages}
+            menuItems={menuItems}
+            productItems={productItems}
+            cateringServices={cateringServices}
+            mobileCafeServices={mobileCafeServices}
+          />
+        );
       case 'local-activation':
-        return <LocalActivation />;
+        return (
+          <LocalActivation
+            eventImages={eventImages}
+            communityProjects={communityProjects}
+            educationMethods={educationMethods}
+            educationSummary={educationSummary}
+          />
+        );
       default:
         return null;
     }

--- a/src/pages/member/Combination.tsx
+++ b/src/pages/member/Combination.tsx
@@ -8,6 +8,16 @@ import {
   OrganizationDetails,
   HwajeonStory,
 } from '@/components/combination';
+import {
+  historyData,
+  teams,
+  cards,
+  storyImages,
+  mainStoryImage,
+  missionVisionData,
+  greetingData,
+  organizationChartData,
+} from '@/components/combination/data';
 
 function Combination() {
   const tabs: TabItem[] = [
@@ -25,31 +35,28 @@ function Combination() {
       case 'greeting':
         return (
           <div className="max-w-5xl mx-auto">
-            <Greeting />
+            <Greeting data={greetingData} />
           </div>
         );
       case 'mission':
-        return <MissionVision />;
+        return <MissionVision data={missionVisionData} />;
       case 'history':
-        return <History />;
+        return <History historyData={historyData} />;
       case 'organization':
         return (
           <div className="max-w-5xl mx-auto space-y-8">
             <OrganizationChart
-              top={{ label: '조합장' }}
-              second={[{ label: '이사회' }, { label: '사무국' }, { label: '감사' }]}
-              teams={[
-                { label: '기획행정팀' },
-                { label: '지역사회팀' },
-                { label: '교육문화팀' },
-                { label: '카페27b운영팀' },
-              ]}
+              top={organizationChartData.top}
+              second={organizationChartData.second}
+              teams={organizationChartData.teams}
             />
-            <OrganizationDetails />
+            <OrganizationDetails teams={teams} />
           </div>
         );
       case 'story':
-        return <HwajeonStory />;
+        return (
+          <HwajeonStory cards={cards} storyImages={storyImages} mainStoryImage={mainStoryImage} />
+        );
       default:
         return null;
     }


### PR DESCRIPTION
## 작업 내용

### 목표
- `@business/` 및 `@combination/` 폴더의 컴포넌트들에서 하드코딩된 데이터를 별도 데이터 파일로 분리
- 컴포넌트의 재사용성과 유지보수성 향상
- 타입 안전성 확보

### 🔧 변경 사항

#### Business 컴포넌트
- `UrbanRegenerationHub`: 아카데미 카드, 교육 카드 데이터 분리
- `EventsEducation`: 이벤트 카드 데이터 분리  
- `Cafe27b`: 메뉴, 상품, 케이터링, 이동카페 서비스 데이터 분리
- `LocalActivation`: 이벤트 이미지, 커뮤니티 프로젝트, 교육 방법 데이터 분리

#### Combination 컴포넌트
- `Greeting`: 인사말 데이터 분리
- `MissionVision`: 미션/비전 데이터 분리
- `History`: 연혁 데이터 분리
- `OrganizationDetails`: 조직도 팀 데이터 분리
- `HwajeonStory`: 화전 이야기 카드, 이미지 데이터 분리


### 개선 사항
- 모든 데이터에 TypeScript 인터페이스 정의
- 컴포넌트 props를 통한 데이터 주입
- 기본값 설정으로 하위 호환성 유지
- 명시적 export로 모듈 충돌 방지

### 테스트
- [x] 모든 컴포넌트 정상 렌더링 확인
- [x] TypeScript 타입 에러 해결
- [x] 기존 UI/UX 동일하게 유지