### PR TITLE
Feat: News 페이지 반응형 UI 및 공용 페이지네이션 컴포넌트 구현

### DIFF
--- a/src/components/news/BoardDetail.tsx
+++ b/src/components/news/BoardDetail.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Detail from './Detail';
 import { type BoardItem } from './data/types';
 
 interface BoardDetailProps {
@@ -10,80 +11,8 @@ interface BoardDetailProps {
   hasNext?: boolean;
 }
 
-const BoardDetail: React.FC<BoardDetailProps> = ({
-  item,
-  onBackToList,
-  onPrevious,
-  onNext,
-  hasPrevious = false,
-  hasNext = false,
-}) => {
-  return (
-    <div className="w-full max-w-5xl mx-auto py-8">
-      {/* 상단 정보 섹션 */}
-      <div className="bg-white border-b border-gray-200 pb-6 mb-6">
-        <div className="flex justify-between items-start">
-          <div className="space-y-4">
-            <div>
-              <span className="text-sm text-gray-500 font-medium">제목</span>
-              <p className="text-lg text-gray-900 font-semibold mt-1">{item.title}</p>
-            </div>
-            <div>
-              <span className="text-sm text-gray-500 font-medium">작성일</span>
-              <p className="text-base text-gray-700 mt-1">{item.date}</p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* 중앙 내용 섹션 */}
-      <div className="bg-white min-h-[400px] py-8">
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-gray-900">내용</h3>
-          <div className="prose prose-gray max-w-none">
-            <p className="text-gray-700 leading-relaxed">
-              {item.content ||
-                '게시물 내용이 여기에 표시됩니다. 실제 구현 시에는 BoardItem 타입에 content 필드를 추가하여 상세 내용을 저장할 수 있습니다.'}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* 하단 네비게이션 버튼 */}
-      <div className="flex justify-center mt-8 space-x-4">
-        <button
-          onClick={onPrevious}
-          disabled={!hasPrevious}
-          className={`px-6 py-3 rounded-lg text-base font-medium transition-colors ${
-            hasPrevious
-              ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              : 'bg-gray-50 text-gray-400 cursor-not-allowed'
-          }`}
-        >
-          이전
-        </button>
-
-        <button
-          onClick={onBackToList}
-          className="px-6 py-3 rounded-lg text-base font-medium bg-gray-200 text-gray-800 hover:bg-gray-300 transition-colors"
-        >
-          목록
-        </button>
-
-        <button
-          onClick={onNext}
-          disabled={!hasNext}
-          className={`px-6 py-3 rounded-lg text-base font-medium transition-colors ${
-            hasNext
-              ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              : 'bg-gray-50 text-gray-400 cursor-not-allowed'
-          }`}
-        >
-          다음
-        </button>
-      </div>
-    </div>
-  );
+const BoardDetail: React.FC<BoardDetailProps> = (props) => {
+  return <Detail<BoardItem> {...props} />;
 };
 
 export default BoardDetail;

--- a/src/components/news/BoardList.tsx
+++ b/src/components/news/BoardList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pagination, PaginationContent, PaginationItem } from '@/components/ui/pagination';
+import CustomPagination from '@/components/ui/CustomPagination';
 import { Button } from '@/components/ui/button';
 import { Settings, Edit, Trash2 } from 'lucide-react';
 
@@ -32,96 +32,6 @@ const BoardList: React.FC<BoardListProps> = ({
   onDelete,
   onSettings,
 }) => {
-  const handlePageChange = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      onPageChange(page);
-    }
-  };
-
-  const renderPaginationItems = () => {
-    const items = [];
-
-    // 첫 페이지 버튼 (<<)
-    items.push(
-      <PaginationItem key="first">
-        <button
-          onClick={() => handlePageChange(1)}
-          disabled={currentPage === 1}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          style={{ backgroundColor: '#2C2E5A29' }}
-        >
-          «
-        </button>
-      </PaginationItem>
-    );
-
-    // 이전 페이지 버튼 (<)
-    items.push(
-      <PaginationItem key="prev">
-        <button
-          onClick={() => handlePageChange(currentPage - 1)}
-          disabled={currentPage === 1}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          style={{ backgroundColor: '#2C2E5A29' }}
-        >
-          ‹
-        </button>
-      </PaginationItem>
-    );
-
-    // 페이지 번호들 (최대 10개 페이지 표시)
-    const maxVisiblePages = 10;
-    const startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2));
-    const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
-
-    for (let i = startPage; i <= endPage; i++) {
-      items.push(
-        <PaginationItem key={i}>
-          <button
-            onClick={() => handlePageChange(i)}
-            className={`px-4 py-3 rounded-lg text-base transition-colors ${
-              i === currentPage
-                ? 'text-gray-900 font-bold border-b-2 border-gray-900'
-                : 'text-gray-800 font-normal hover:text-gray-900'
-            }`}
-          >
-            {i}
-          </button>
-        </PaginationItem>
-      );
-    }
-
-    // 다음 페이지 버튼 (>)
-    items.push(
-      <PaginationItem key="next">
-        <button
-          onClick={() => handlePageChange(currentPage + 1)}
-          disabled={currentPage === totalPages}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          style={{ backgroundColor: '#2C2E5A29' }}
-        >
-          ›
-        </button>
-      </PaginationItem>
-    );
-
-    // 마지막 페이지 버튼 (>>)
-    items.push(
-      <PaginationItem key="last">
-        <button
-          onClick={() => handlePageChange(totalPages)}
-          disabled={currentPage === totalPages}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          style={{ backgroundColor: '#2C2E5A29' }}
-        >
-          »
-        </button>
-      </PaginationItem>
-    );
-
-    return items;
-  };
-
   return (
     <div className="w-full">
       {/* 게시판 목록 테이블 */}
@@ -161,9 +71,11 @@ const BoardList: React.FC<BoardListProps> = ({
       {/* 페이지네이션 */}
       <div className="flex items-center justify-between mt-6">
         <div className="flex-1 flex justify-center">
-          <Pagination>
-            <PaginationContent className="gap-3">{renderPaginationItems()}</PaginationContent>
-          </Pagination>
+          <CustomPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={onPageChange}
+          />
         </div>
 
         {/* 관리자 액션 버튼들 */}

--- a/src/components/news/BoardList.tsx
+++ b/src/components/news/BoardList.tsx
@@ -34,8 +34,8 @@ const BoardList: React.FC<BoardListProps> = ({
 }) => {
   return (
     <div className="w-full">
-      {/* 게시판 목록 테이블 */}
-      <div className="bg-white overflow-hidden">
+      {/* 데스크톱 테이블 (md 이상) */}
+      <div className="hidden md:block bg-white overflow-hidden">
         <table className="w-full">
           <thead className="bg-gray-50">
             <tr>
@@ -66,6 +66,23 @@ const BoardList: React.FC<BoardListProps> = ({
             ))}
           </tbody>
         </table>
+      </div>
+
+      {/* 모바일 카드 레이아웃 (md 미만) */}
+      <div className="md:hidden space-y-3">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow cursor-pointer"
+            onClick={() => onItemClick?.(item)}
+          >
+            <div className="flex justify-between items-start mb-2">
+              <span className="text-sm text-gray-500">#{item.id}</span>
+              <span className="text-xs text-gray-500">{item.date}</span>
+            </div>
+            <h3 className="text-base font-medium text-gray-900 line-clamp-2">{item.title}</h3>
+          </div>
+        ))}
       </div>
 
       {/* 페이지네이션 */}

--- a/src/components/news/Detail.tsx
+++ b/src/components/news/Detail.tsx
@@ -1,0 +1,94 @@
+// 공통 아이템 타입 (BoardItem과 GalleryItem의 공통 필드)
+interface BaseItem {
+  id: number;
+  title: string;
+  date: string;
+  content?: string;
+}
+
+interface DetailProps<T extends BaseItem> {
+  item: T;
+  onBackToList: () => void;
+  onPrevious?: () => void;
+  onNext?: () => void;
+  hasPrevious?: boolean;
+  hasNext?: boolean;
+}
+
+const Detail = <T extends BaseItem>({
+  item,
+  onBackToList,
+  onPrevious,
+  onNext,
+  hasPrevious = false,
+  hasNext = false,
+}: DetailProps<T>) => {
+  return (
+    <div className="w-full max-w-5xl mx-auto py-8">
+      {/* 상단 정보 섹션 */}
+      <div className="bg-white border-b border-gray-200 pb-6 mb-6">
+        <div className="flex justify-between items-start">
+          <div className="space-y-4">
+            <div>
+              <span className="text-sm text-gray-500 font-medium">제목</span>
+              <p className="text-lg text-gray-900 font-semibold mt-1">{item.title}</p>
+            </div>
+            <div>
+              <span className="text-sm text-gray-500 font-medium">작성일</span>
+              <p className="text-base text-gray-700 mt-1">{item.date}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 중앙 내용 섹션 */}
+      <div className="bg-white min-h-[400px] py-8">
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">내용</h3>
+          <div className="prose prose-gray max-w-none">
+            <p className="text-gray-700 leading-relaxed">
+              {item.content ||
+                '게시물 내용이 여기에 표시됩니다. 실제 구현 시에는 content 필드를 추가하여 상세 내용을 저장할 수 있습니다.'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 하단 네비게이션 버튼 */}
+      <div className="flex justify-center mt-8 space-x-4">
+        <button
+          onClick={onPrevious}
+          disabled={!hasPrevious}
+          className={`px-6 py-3 rounded-lg text-base font-medium transition-colors ${
+            hasPrevious
+              ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              : 'bg-gray-50 text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          이전
+        </button>
+
+        <button
+          onClick={onBackToList}
+          className="px-6 py-3 rounded-lg text-base font-medium bg-gray-200 text-gray-800 hover:bg-gray-300 transition-colors"
+        >
+          목록
+        </button>
+
+        <button
+          onClick={onNext}
+          disabled={!hasNext}
+          className={`px-6 py-3 rounded-lg text-base font-medium transition-colors ${
+            hasNext
+              ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              : 'bg-gray-50 text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          다음
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Detail;

--- a/src/components/news/Detail.tsx
+++ b/src/components/news/Detail.tsx
@@ -24,29 +24,29 @@ const Detail = <T extends BaseItem>({
   hasNext = false,
 }: DetailProps<T>) => {
   return (
-    <div className="w-full max-w-5xl mx-auto py-8">
+    <div className="w-full max-w-5xl mx-auto py-4 sm:py-8 px-4 sm:px-0">
       {/* 상단 정보 섹션 */}
-      <div className="bg-white border-b border-gray-200 pb-6 mb-6">
-        <div className="flex justify-between items-start">
-          <div className="space-y-4">
-            <div>
-              <span className="text-sm text-gray-500 font-medium">제목</span>
-              <p className="text-lg text-gray-900 font-semibold mt-1">{item.title}</p>
-            </div>
-            <div>
-              <span className="text-sm text-gray-500 font-medium">작성일</span>
-              <p className="text-base text-gray-700 mt-1">{item.date}</p>
-            </div>
+      <div className="bg-white border-b border-gray-200 pb-4 sm:pb-6 mb-4 sm:mb-6">
+        <div className="space-y-4">
+          <div>
+            <span className="text-sm text-gray-500 font-medium">제목</span>
+            <p className="text-base sm:text-lg text-gray-900 font-semibold mt-1 break-words">
+              {item.title}
+            </p>
+          </div>
+          <div>
+            <span className="text-sm text-gray-500 font-medium">작성일</span>
+            <p className="text-sm sm:text-base text-gray-700 mt-1">{item.date}</p>
           </div>
         </div>
       </div>
 
       {/* 중앙 내용 섹션 */}
-      <div className="bg-white min-h-[400px] py-8">
+      <div className="bg-white min-h-[300px] sm:min-h-[400px] py-4 sm:py-8">
         <div className="space-y-4">
-          <h3 className="text-lg font-semibold text-gray-900">내용</h3>
+          <h3 className="text-base sm:text-lg font-semibold text-gray-900">내용</h3>
           <div className="prose prose-gray max-w-none">
-            <p className="text-gray-700 leading-relaxed">
+            <p className="text-sm sm:text-base text-gray-700 leading-relaxed break-words">
               {item.content ||
                 '게시물 내용이 여기에 표시됩니다. 실제 구현 시에는 content 필드를 추가하여 상세 내용을 저장할 수 있습니다.'}
             </p>
@@ -55,7 +55,7 @@ const Detail = <T extends BaseItem>({
       </div>
 
       {/* 하단 네비게이션 버튼 */}
-      <div className="flex justify-center mt-8 space-x-4">
+      <div className="flex flex-col sm:flex-row justify-center mt-6 sm:mt-8 space-y-2 sm:space-y-0 sm:space-x-4">
         <button
           onClick={onPrevious}
           disabled={!hasPrevious}

--- a/src/components/news/EventCalendarTab.tsx
+++ b/src/components/news/EventCalendarTab.tsx
@@ -27,13 +27,19 @@ function EventCalendarTab({ events }: EventCalendarTabProps) {
   };
 
   return (
-    <div className="py-8 max-w-5xl mx-auto">
-      <div className="mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">행사 캘린더</h2>
-        <p className="text-gray-600">화전마을의 다양한 행사와 일정을 확인하세요.</p>
+    <div className="py-2 sm:py-4 md:py-6 lg:py-8 max-w-7xl mx-auto px-2 sm:px-4 md:px-6 lg:px-8">
+      {/* 헤더 섹션 */}
+      <div className="mb-3 sm:mb-4 md:mb-5 lg:mb-6">
+        <h2 className="text-lg sm:text-xl md:text-2xl lg:text-3xl font-bold text-gray-900 mb-1 sm:mb-2">
+          행사 캘린더
+        </h2>
+        <p className="text-xs sm:text-sm md:text-base lg:text-lg text-gray-600 leading-relaxed">
+          화전마을의 다양한 행사와 일정을 확인하세요.
+        </p>
       </div>
 
-      <div>
+      {/* 캘린더 컨테이너 */}
+      <div className="w-full">
         <EventCalendar
           events={getCurrentMonthEvents()}
           onDateClick={handleDateClick}

--- a/src/components/news/EventList.tsx
+++ b/src/components/news/EventList.tsx
@@ -58,10 +58,10 @@ function EventList({ events, itemsPerPage = 4 }: EventListProps) {
           {paginatedEvents.map((event) => (
             <div
               key={event.id}
-              className="flex gap-4 p-4 border border-gray-200 rounded-lg hover:shadow-md transition-shadow"
+              className="flex flex-col sm:flex-row gap-4 p-4 border border-gray-200 rounded-lg hover:shadow-md transition-shadow"
             >
               {/* 이미지 영역 */}
-              <div className="flex-shrink-0 w-32 h-24 bg-gray-200 rounded-lg flex items-center justify-center">
+              <div className="flex-shrink-0 w-full sm:w-32 h-32 sm:h-24 bg-gray-200 rounded-lg flex items-center justify-center">
                 <span className="text-gray-500 text-sm">이미지</span>
               </div>
 
@@ -78,7 +78,7 @@ function EventList({ events, itemsPerPage = 4 }: EventListProps) {
                 </div>
 
                 {/* 제목 */}
-                <h3 className="text-lg font-bold text-gray-900 mb-2">{event.title}</h3>
+                <h3 className="text-base sm:text-lg font-bold text-gray-900 mb-2">{event.title}</h3>
 
                 {/* 내용 */}
                 <p className="text-gray-600 text-sm mb-3 line-clamp-2">{event.content}</p>

--- a/src/components/news/EventList.tsx
+++ b/src/components/news/EventList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import CustomPagination from '@/components/ui/CustomPagination';
 import { type EventData, type CategoryFilter, LIST_CATEGORY_CONFIG } from './data/types';
 
 interface EventListProps {
@@ -92,51 +93,11 @@ function EventList({ events, itemsPerPage = 4 }: EventListProps) {
         {/* 페이지네이션 */}
         {totalPages > 0 && (
           <div className="flex items-center justify-center mt-6">
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => handlePageChange(1)}
-                disabled={currentPage === 1}
-                className="p-2 rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                &lt;&lt;
-              </button>
-              <button
-                onClick={() => handlePageChange(currentPage - 1)}
-                disabled={currentPage === 1}
-                className="p-2 rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                &lt;
-              </button>
-
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
-                <button
-                  key={page}
-                  onClick={() => handlePageChange(page)}
-                  className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    currentPage === page
-                      ? 'bg-gray-900 text-white'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  {page}
-                </button>
-              ))}
-
-              <button
-                onClick={() => handlePageChange(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                className="p-2 rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                &gt;
-              </button>
-              <button
-                onClick={() => handlePageChange(totalPages)}
-                disabled={currentPage === totalPages}
-                className="p-2 rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                &gt;&gt;
-              </button>
-            </div>
+            <CustomPagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
           </div>
         )}
       </div>

--- a/src/components/news/GalleryDetail.tsx
+++ b/src/components/news/GalleryDetail.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Detail from './Detail';
+import { type GalleryItem } from './data/types';
+
+interface GalleryDetailProps {
+  item: GalleryItem;
+  onBackToList: () => void;
+  onPrevious?: () => void;
+  onNext?: () => void;
+  hasPrevious?: boolean;
+  hasNext?: boolean;
+}
+
+const GalleryDetail: React.FC<GalleryDetailProps> = (props) => {
+  return <Detail<GalleryItem> {...props} />;
+};
+
+export default GalleryDetail;

--- a/src/components/news/GalleryList.tsx
+++ b/src/components/news/GalleryList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pagination, PaginationContent, PaginationItem } from '@/components/ui/pagination';
+import CustomPagination from '@/components/ui/CustomPagination';
 import { type GalleryItem, type NewsItem } from './data/types';
 
 type GalleryItemType = GalleryItem | NewsItem;
@@ -21,96 +21,6 @@ const GalleryList: React.FC<GalleryListProps> = ({
   onItemClick,
   type = 'news',
 }) => {
-  const handlePageChange = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      onPageChange(page);
-    }
-  };
-
-  const renderPaginationItems = () => {
-    const items = [];
-
-    // 첫 페이지 버튼 (<<)
-    items.push(
-      <PaginationItem key="first">
-        <button
-          onClick={() => handlePageChange(1)}
-          disabled={currentPage === 1}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          style={{ backgroundColor: '#2C2E5A29' }}
-        >
-          «
-        </button>
-      </PaginationItem>
-    );
-
-    // 이전 페이지 버튼 (<)
-    items.push(
-      <PaginationItem key="prev">
-        <button
-          onClick={() => handlePageChange(currentPage - 1)}
-          disabled={currentPage === 1}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          style={{ backgroundColor: '#2C2E5A29' }}
-        >
-          ‹
-        </button>
-      </PaginationItem>
-    );
-
-    // 페이지 번호들 (최대 10개 페이지 표시)
-    const maxVisiblePages = 10;
-    const startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2));
-    const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
-
-    for (let i = startPage; i <= endPage; i++) {
-      items.push(
-        <PaginationItem key={i}>
-          <button
-            onClick={() => handlePageChange(i)}
-            className={`px-4 py-3 rounded-lg text-base transition-colors ${
-              i === currentPage
-                ? 'text-gray-900 font-bold border-b-2 border-gray-900'
-                : 'text-gray-800 font-normal hover:text-gray-900'
-            }`}
-          >
-            {i}
-          </button>
-        </PaginationItem>
-      );
-    }
-
-    // 다음 페이지 버튼 (>)
-    items.push(
-      <PaginationItem key="next">
-        <button
-          onClick={() => handlePageChange(currentPage + 1)}
-          disabled={currentPage === totalPages}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          style={{ backgroundColor: '#2C2E5A29' }}
-        >
-          ›
-        </button>
-      </PaginationItem>
-    );
-
-    // 마지막 페이지 버튼 (>>)
-    items.push(
-      <PaginationItem key="last">
-        <button
-          onClick={() => handlePageChange(totalPages)}
-          disabled={currentPage === totalPages}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          style={{ backgroundColor: '#2C2E5A29' }}
-        >
-          »
-        </button>
-      </PaginationItem>
-    );
-
-    return items;
-  };
-
   return (
     <div className="w-full">
       {/* 갤러리 그리드 */}
@@ -171,9 +81,11 @@ const GalleryList: React.FC<GalleryListProps> = ({
 
       {/* 페이지네이션 */}
       <div className="flex items-center justify-center">
-        <Pagination>
-          <PaginationContent className="gap-3">{renderPaginationItems()}</PaginationContent>
-        </Pagination>
+        <CustomPagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={onPageChange}
+        />
       </div>
     </div>
   );

--- a/src/components/news/GalleryList.tsx
+++ b/src/components/news/GalleryList.tsx
@@ -24,7 +24,7 @@ const GalleryList: React.FC<GalleryListProps> = ({
   return (
     <div className="w-full">
       {/* 갤러리 그리드 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+      <div className="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
         {items.map((item) => (
           <div
             key={item.id}

--- a/src/components/news/GalleryWrapper.tsx
+++ b/src/components/news/GalleryWrapper.tsx
@@ -19,13 +19,36 @@ const GalleryWrapper: React.FC<GalleryWrapperProps> = ({
   title,
   items,
   boardType,
-  itemsPerPage = 9, // 갤러리는 3x3 그리드로 9개씩
+  itemsPerPage: propItemsPerPage,
   onItemClick,
   type = 'news',
 }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedItem, setSelectedItem] = useState<GalleryItem | null>(null);
+  const [responsiveItemsPerPage, setResponsiveItemsPerPage] = useState(9);
+
+  // 반응형 itemsPerPage 설정
+  useEffect(() => {
+    const updateItemsPerPage = () => {
+      const width = window.innerWidth;
+      if (width >= 1024) {
+        setResponsiveItemsPerPage(9); // lg: 3x3
+      } else if (width >= 768) {
+        setResponsiveItemsPerPage(6); // md: 2x3
+      } else if (width >= 640) {
+        setResponsiveItemsPerPage(5); // sm: 1x5
+      } else {
+        setResponsiveItemsPerPage(4); // 모바일: 1x4
+      }
+    };
+
+    updateItemsPerPage();
+    window.addEventListener('resize', updateItemsPerPage);
+    return () => window.removeEventListener('resize', updateItemsPerPage);
+  }, []);
+
+  const itemsPerPage = propItemsPerPage || responsiveItemsPerPage;
 
   // URL 파라미터에서 아이템 ID와 페이지 확인 (탭별로 독립적)
   const itemId = searchParams.get(`${boardType}_id`);

--- a/src/components/news/GalleryWrapper.tsx
+++ b/src/components/news/GalleryWrapper.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import GalleryList from './GalleryList';
+import GalleryDetail from './GalleryDetail';
 import { type GalleryItem, type NewsItem } from './data/types';
 
 type GalleryItemType = GalleryItem | NewsItem;
@@ -116,77 +117,19 @@ const GalleryWrapper: React.FC<GalleryWrapperProps> = ({
     }
   };
 
-  // 상세 페이지가 선택된 경우 (갤러리 상세 모달 또는 페이지)
+  // 상세 페이지가 선택된 경우 GalleryDetail 컴포넌트 사용
   if (selectedItem) {
     const currentIndex = getCurrentItemIndex();
 
     return (
-      <div className="w-full max-w-5xl mx-auto py-8">
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-          {/* 이미지 */}
-          <div className="aspect-[16/9] bg-gray-200 flex items-center justify-center">
-            {selectedItem.imageUrl ? (
-              <img
-                src={selectedItem.imageUrl}
-                alt={selectedItem.title}
-                className="w-full h-full object-cover"
-              />
-            ) : (
-              <span className="text-gray-500 text-lg">이미지</span>
-            )}
-          </div>
-
-          {/* 내용 */}
-          <div className="p-8">
-            <div className="flex justify-between items-start mb-6">
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900 mb-2">{selectedItem.title}</h1>
-                <p className="text-gray-500">{selectedItem.date}</p>
-              </div>
-            </div>
-
-            <div className="prose prose-gray max-w-none">
-              <p className="text-gray-700 leading-relaxed whitespace-pre-line">
-                {selectedItem.content}
-              </p>
-            </div>
-          </div>
-
-          {/* 네비게이션 버튼 */}
-          <div className="flex justify-center p-6 border-t border-gray-200 space-x-4">
-            <button
-              onClick={handlePrevious}
-              disabled={currentIndex <= 0}
-              className={`px-6 py-3 rounded-lg text-base font-medium transition-colors ${
-                currentIndex > 0
-                  ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  : 'bg-gray-50 text-gray-400 cursor-not-allowed'
-              }`}
-            >
-              이전
-            </button>
-
-            <button
-              onClick={handleBackToList}
-              className="px-6 py-3 rounded-lg text-base font-medium bg-gray-200 text-gray-800 hover:bg-gray-300 transition-colors"
-            >
-              목록
-            </button>
-
-            <button
-              onClick={handleNext}
-              disabled={currentIndex >= items.length - 1}
-              className={`px-6 py-3 rounded-lg text-base font-medium transition-colors ${
-                currentIndex < items.length - 1
-                  ? 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  : 'bg-gray-50 text-gray-400 cursor-not-allowed'
-              }`}
-            >
-              다음
-            </button>
-          </div>
-        </div>
-      </div>
+      <GalleryDetail
+        item={selectedItem}
+        onBackToList={handleBackToList}
+        onPrevious={handlePrevious}
+        onNext={handleNext}
+        hasPrevious={currentIndex > 0}
+        hasNext={currentIndex < items.length - 1}
+      />
     );
   }
 

--- a/src/components/news/index.ts
+++ b/src/components/news/index.ts
@@ -6,6 +6,8 @@ export { default as EventCalendarTab } from './EventCalendarTab';
 export { default as EventList } from './EventList';
 export { default as GalleryList } from './GalleryList';
 export { default as GalleryWrapper } from './GalleryWrapper';
+export { default as GalleryDetail } from './GalleryDetail';
+export { default as Detail } from './Detail';
 export type { BoardItem } from './BoardList';
 export type {
   EventCategory,

--- a/src/components/ui/CustomPagination.tsx
+++ b/src/components/ui/CustomPagination.tsx
@@ -52,10 +52,10 @@ const CustomPagination: React.FC<CustomPaginationProps> = ({
 
     // 페이지 번호들 (화면 크기에 따라 표시 개수 조정)
     const getVisiblePages = () => {
-      if (window.innerWidth < 640) return 3; // 모바일: 3개
-      if (window.innerWidth < 768) return 5; // sm: 5개
-      if (window.innerWidth < 1024) return 7; // md: 7개
-      return 10; // lg 이상: 10개
+      if (window.innerWidth < 640) return Math.min(3, maxVisiblePages); // 모바일: 3개
+      if (window.innerWidth < 768) return Math.min(5, maxVisiblePages); // sm: 5개
+      if (window.innerWidth < 1024) return Math.min(7, maxVisiblePages); // md: 7개
+      return maxVisiblePages; // lg 이상: maxVisiblePages 개
     };
 
     const visiblePages = getVisiblePages();

--- a/src/components/ui/CustomPagination.tsx
+++ b/src/components/ui/CustomPagination.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+
+interface CustomPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  maxVisiblePages?: number;
+}
+
+const CustomPagination: React.FC<CustomPaginationProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+  maxVisiblePages = 10,
+}) => {
+  const handlePageChange = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      onPageChange(page);
+    }
+  };
+
+  const renderPaginationItems = () => {
+    const items = [];
+
+    // 첫 페이지 버튼 (<<)
+    items.push(
+      <li key="first">
+        <button
+          onClick={() => handlePageChange(1)}
+          disabled={currentPage === 1}
+          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          style={{ backgroundColor: '#2C2E5A29' }}
+        >
+          «
+        </button>
+      </li>
+    );
+
+    // 이전 페이지 버튼 (<)
+    items.push(
+      <li key="prev">
+        <button
+          onClick={() => handlePageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          style={{ backgroundColor: '#2C2E5A29' }}
+        >
+          ‹
+        </button>
+      </li>
+    );
+
+    // 페이지 번호들 (최대 10개 페이지 표시)
+    const startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2));
+    const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+
+    for (let i = startPage; i <= endPage; i++) {
+      items.push(
+        <li key={i}>
+          <button
+            onClick={() => handlePageChange(i)}
+            className={`px-4 py-3 rounded-lg text-base transition-colors ${
+              i === currentPage
+                ? 'text-gray-900 font-bold border-b-2 border-gray-900'
+                : 'text-gray-800 font-normal hover:text-gray-900'
+            }`}
+          >
+            {i}
+          </button>
+        </li>
+      );
+    }
+
+    // 다음 페이지 버튼 (>)
+    items.push(
+      <li key="next">
+        <button
+          onClick={() => handlePageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          style={{ backgroundColor: '#2C2E5A29' }}
+        >
+          ›
+        </button>
+      </li>
+    );
+
+    // 마지막 페이지 버튼 (>>)
+    items.push(
+      <li key="last">
+        <button
+          onClick={() => handlePageChange(totalPages)}
+          disabled={currentPage === totalPages}
+          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          style={{ backgroundColor: '#2C2E5A29' }}
+        >
+          »
+        </button>
+      </li>
+    );
+
+    return items;
+  };
+
+  return (
+    <nav className="mx-auto flex w-full justify-center">
+      <ul className="flex flex-row items-center gap-3">{renderPaginationItems()}</ul>
+    </nav>
+  );
+};
+
+export default CustomPagination;

--- a/src/components/ui/CustomPagination.tsx
+++ b/src/components/ui/CustomPagination.tsx
@@ -28,7 +28,7 @@ const CustomPagination: React.FC<CustomPaginationProps> = ({
         <button
           onClick={() => handlePageChange(1)}
           disabled={currentPage === 1}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 md:py-3 rounded-md sm:rounded-lg text-xs sm:text-sm md:text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           style={{ backgroundColor: '#2C2E5A29' }}
         >
           «
@@ -42,7 +42,7 @@ const CustomPagination: React.FC<CustomPaginationProps> = ({
         <button
           onClick={() => handlePageChange(currentPage - 1)}
           disabled={currentPage === 1}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 md:py-3 rounded-md sm:rounded-lg text-xs sm:text-sm md:text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           style={{ backgroundColor: '#2C2E5A29' }}
         >
           ‹
@@ -50,16 +50,24 @@ const CustomPagination: React.FC<CustomPaginationProps> = ({
       </li>
     );
 
-    // 페이지 번호들 (최대 10개 페이지 표시)
-    const startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2));
-    const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+    // 페이지 번호들 (화면 크기에 따라 표시 개수 조정)
+    const getVisiblePages = () => {
+      if (window.innerWidth < 640) return 3; // 모바일: 3개
+      if (window.innerWidth < 768) return 5; // sm: 5개
+      if (window.innerWidth < 1024) return 7; // md: 7개
+      return 10; // lg 이상: 10개
+    };
+
+    const visiblePages = getVisiblePages();
+    const startPage = Math.max(1, currentPage - Math.floor(visiblePages / 2));
+    const endPage = Math.min(totalPages, startPage + visiblePages - 1);
 
     for (let i = startPage; i <= endPage; i++) {
       items.push(
         <li key={i}>
           <button
             onClick={() => handlePageChange(i)}
-            className={`px-4 py-3 rounded-lg text-base transition-colors ${
+            className={`px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 md:py-3 rounded-md sm:rounded-lg text-xs sm:text-sm md:text-base transition-colors ${
               i === currentPage
                 ? 'text-gray-900 font-bold border-b-2 border-gray-900'
                 : 'text-gray-800 font-normal hover:text-gray-900'
@@ -77,7 +85,7 @@ const CustomPagination: React.FC<CustomPaginationProps> = ({
         <button
           onClick={() => handlePageChange(currentPage + 1)}
           disabled={currentPage === totalPages}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 md:py-3 rounded-md sm:rounded-lg text-xs sm:text-sm md:text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           style={{ backgroundColor: '#2C2E5A29' }}
         >
           ›
@@ -91,7 +99,7 @@ const CustomPagination: React.FC<CustomPaginationProps> = ({
         <button
           onClick={() => handlePageChange(totalPages)}
           disabled={currentPage === totalPages}
-          className="px-4 py-3 rounded-lg text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 md:py-3 rounded-md sm:rounded-lg text-xs sm:text-sm md:text-base font-bold text-gray-800 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           style={{ backgroundColor: '#2C2E5A29' }}
         >
           »
@@ -103,8 +111,10 @@ const CustomPagination: React.FC<CustomPaginationProps> = ({
   };
 
   return (
-    <nav className="mx-auto flex w-full justify-center">
-      <ul className="flex flex-row items-center gap-3">{renderPaginationItems()}</ul>
+    <nav className="mx-auto flex w-full justify-center px-2 sm:px-4">
+      <ul className="flex flex-row items-center gap-1 sm:gap-2 md:gap-3 flex-wrap justify-center">
+        {renderPaginationItems()}
+      </ul>
     </nav>
   );
 };

--- a/src/pages/member/News.tsx
+++ b/src/pages/member/News.tsx
@@ -41,7 +41,6 @@ function News() {
               title="화전 소식"
               items={newsData.newsItems}
               boardType="news"
-              itemsPerPage={9}
               type="news"
             />
           </div>
@@ -53,7 +52,6 @@ function News() {
               title="활동 갤러리"
               items={galleryData.galleryItems}
               boardType="gallery"
-              itemsPerPage={9}
               type="gallery"
             />
           </div>


### PR DESCRIPTION
## 개요
News 페이지의 모든 컴포넌트에 반응형 레이아웃을 구현하고, 공용 페이지네이션 컴포넌트를 생성하여 UI 일관성을 향상시켰습니다.

## 주요 변경사항

### 반응형 레이아웃 구현
- **EventList**: 모바일 세로 배치, 데스크톱 가로 배치
- **BoardList**: 데스크톱 테이블, 모바일 카드 레이아웃 분리
- **Detail**: 패딩, 텍스트 크기, 네비게이션 버튼 반응형 조정
- **EventCalendarTab**: 모든 디바이스 크기에 맞는 레이아웃 최적화
- **GalleryList**: 세로 배치 중심 그리드 설정

### 공용 컴포넌트 생성
- **CustomPagination**: BoardList 스타일 기반 재사용 가능한 페이지네이션
- **Detail**: 제네릭 타입으로 BoardDetail, GalleryDetail 통합
- **GalleryWrapper**: 반응형 itemsPerPage 로직 추가

### 반응형 개선사항
- 모바일 우선 반응형 디자인 적용
- 터치 친화적 UI 및 가독성 향상
- 화면 크기별 적절한 아이템 개수 표시
- 긴 텍스트 처리 및 레이아웃 최적화

## 테스트
- [x] 모바일 (320px~640px) 레이아웃 확인
- [x] 태블릿 (640px~1024px) 레이아웃 확인  
- [x] 데스크톱 (1024px+) 레이아웃 확인
- [x] 페이지네이션 동작 확인
- [x] 상세 페이지 네비게이션 확인