### PR TITLE
Refactor: Admin 페이지 UI 컴포넌트 분리

### DIFF
--- a/src/components/admin/CreatePost/CreatePostForm.tsx
+++ b/src/components/admin/CreatePost/CreatePostForm.tsx
@@ -1,0 +1,192 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface CreatePostFormProps {
+  title: string;
+  content: string;
+  postType: string;
+  eventDate: string;
+  activityType: string;
+  thumbnail: File | null;
+  attachments: File[];
+  isLoading: boolean;
+  categoryInfo: Record<string, { name: string; viewType: string; hasThumbnail: boolean }>;
+  onTitleChange: (value: string) => void;
+  onContentChange: (value: string) => void;
+  onPostTypeChange: (value: string) => void;
+  onEventDateChange: (value: string) => void;
+  onActivityTypeChange: (value: string) => void;
+  onThumbnailChange: (file: File | null) => void;
+  onAttachmentsChange: (files: File[]) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onCancel: () => void;
+}
+
+export const CreatePostForm = ({
+  title,
+  content,
+  postType,
+  eventDate,
+  activityType,
+  thumbnail,
+  attachments,
+  isLoading,
+  categoryInfo,
+  onTitleChange,
+  onContentChange,
+  onPostTypeChange,
+  onEventDateChange,
+  onActivityTypeChange,
+  onThumbnailChange,
+  onAttachmentsChange,
+  onSubmit,
+  onCancel,
+}: CreatePostFormProps) => {
+  return (
+    <div className="min-h-screen bg-gray-50 py-6">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>새 게시글 작성</CardTitle>
+            <CardDescription>게시글을 작성하고 게시하세요</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={onSubmit} className="space-y-6">
+              {/* 제목 */}
+              <div className="space-y-2">
+                <Label htmlFor="title">제목 *</Label>
+                <Input
+                  id="title"
+                  value={title}
+                  onChange={(e) => onTitleChange(e.target.value)}
+                  placeholder="게시글 제목을 입력하세요"
+                  required
+                  disabled={isLoading}
+                />
+              </div>
+
+              {/* 카테고리 */}
+              <div className="space-y-2">
+                <Label htmlFor="postType">카테고리 *</Label>
+                <Select value={postType} onValueChange={onPostTypeChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="카테고리를 선택하세요" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="NOTICE">공지사항</SelectItem>
+                    <SelectItem value="ARCHIVE">자료실</SelectItem>
+                    <SelectItem value="MEETING">정기회의</SelectItem>
+                    <SelectItem value="NEWS">화전 소식</SelectItem>
+                    <SelectItem value="GALLERY">활동 갤러리</SelectItem>
+                    <SelectItem value="CALENDAR">행사 캘린더</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* 행사 날짜 (CALENDAR 카테고리일 때만) */}
+              {postType === 'CALENDAR' && (
+                <div className="space-y-2">
+                  <Label htmlFor="eventDate">행사 날짜 *</Label>
+                  <Input
+                    id="eventDate"
+                    type="datetime-local"
+                    value={eventDate}
+                    onChange={(e) => onEventDateChange(e.target.value)}
+                    required
+                    disabled={isLoading}
+                  />
+                </div>
+              )}
+
+              {/* 활동 유형 (GALLERY 또는 CALENDAR 카테고리일 때만) */}
+              {(postType === 'GALLERY' || postType === 'CALENDAR') && (
+                <div className="space-y-2">
+                  <Label htmlFor="activityType">활동 유형</Label>
+                  <Select value={activityType} onValueChange={onActivityTypeChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="활동 유형을 선택하세요" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="NONE">없음</SelectItem>
+                      <SelectItem value="FESTIVAL">축제</SelectItem>
+                      <SelectItem value="ONE_DAY_CLASS">원데이클래스</SelectItem>
+                      <SelectItem value="CONFERENCE">회의</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+              {/* 썸네일 (THUMBNAIL 뷰타입만) */}
+              {categoryInfo[postType]?.hasThumbnail && (
+                <div className="space-y-2">
+                  <Label htmlFor="thumbnail">썸네일 이미지</Label>
+                  <Input
+                    id="thumbnail"
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => onThumbnailChange(e.target.files?.[0] || null)}
+                    disabled={isLoading}
+                  />
+                  {thumbnail && (
+                    <p className="text-sm text-gray-600">선택된 파일: {thumbnail.name}</p>
+                  )}
+                </div>
+              )}
+
+              {/* 첨부 파일 */}
+              <div className="space-y-2">
+                <Label htmlFor="attachments">첨부 파일</Label>
+                <Input
+                  id="attachments"
+                  type="file"
+                  multiple
+                  onChange={(e) => onAttachmentsChange(Array.from(e.target.files || []))}
+                  disabled={isLoading}
+                />
+                {attachments.length > 0 && (
+                  <div className="text-sm text-gray-600">
+                    선택된 파일: {attachments.map((f) => f.name).join(', ')}
+                  </div>
+                )}
+              </div>
+
+              {/* 내용 */}
+              <div className="space-y-2">
+                <Label htmlFor="content">내용 *</Label>
+                <Textarea
+                  id="content"
+                  value={content}
+                  onChange={(e) => onContentChange(e.target.value)}
+                  placeholder="게시글 내용을 입력하세요"
+                  rows={10}
+                  required
+                  disabled={isLoading}
+                />
+              </div>
+
+              {/* 버튼 */}
+              <div className="flex justify-end space-x-4">
+                <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading}>
+                  취소
+                </Button>
+                <Button type="submit" disabled={isLoading}>
+                  {isLoading ? '작성 중...' : '게시글 작성'}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/CreatePost/index.ts
+++ b/src/components/admin/CreatePost/index.ts
@@ -1,0 +1,1 @@
+export { CreatePostForm } from './CreatePostForm';

--- a/src/components/admin/Dashboard/DashboardHeader.tsx
+++ b/src/components/admin/Dashboard/DashboardHeader.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button';
+
+interface User {
+  id: string;
+  username: string;
+  name: string;
+  realName: string;
+  role: 'TEACHER' | 'USER';
+}
+
+interface DashboardHeaderProps {
+  user: User | null;
+  onLogout: () => void;
+}
+
+export const DashboardHeader = ({ user, onLogout }: DashboardHeaderProps) => {
+  return (
+    <header className="bg-white shadow-sm border-b">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900">화전 관리자 대시보드</h1>
+          </div>
+          <div className="flex items-center space-x-4">
+            <span className="text-sm text-gray-600">안녕하세요, {user?.realName}님</span>
+            <Button variant="outline" onClick={onLogout}>
+              로그아웃
+            </Button>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/src/components/admin/Dashboard/DashboardStats.tsx
+++ b/src/components/admin/Dashboard/DashboardStats.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface DashboardStatsProps {
+  selectedCategory: string;
+  searchTerm: string;
+  categoryInfo: Record<string, { name: string; viewType: string; hasThumbnail: boolean }>;
+  onCategoryChange: (value: string) => void;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onCreatePost: () => void;
+}
+
+export const DashboardStats = ({
+  selectedCategory,
+  searchTerm,
+  categoryInfo,
+  onCategoryChange,
+  onSearchChange,
+  onCreatePost,
+}: DashboardStatsProps) => {
+  return (
+    <>
+      {/* 상단 액션 버튼 */}
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">게시글 관리</h2>
+        <Button onClick={onCreatePost}>새 게시글 작성</Button>
+      </div>
+
+      {/* 필터 및 검색 */}
+      <div className="bg-white p-4 rounded-lg shadow-sm mb-6">
+        <div className="flex flex-col sm:flex-row gap-4">
+          {/* 검색 */}
+          <div className="flex-1">
+            <Input
+              placeholder="제목 또는 내용으로 검색..."
+              value={searchTerm}
+              onChange={onSearchChange}
+              className="w-full"
+            />
+          </div>
+
+          {/* 카테고리 필터 */}
+          <div className="sm:w-48">
+            <Select value={selectedCategory} onValueChange={onCategoryChange}>
+              <SelectTrigger>
+                <SelectValue placeholder="카테고리 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(categoryInfo).map(([key, info]) => (
+                  <SelectItem key={key} value={key}>
+                    {info.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/admin/Dashboard/DashboardTable.tsx
+++ b/src/components/admin/Dashboard/DashboardTable.tsx
@@ -1,0 +1,151 @@
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { Post, PostCategory } from '../../../pages/admin/data';
+
+interface DashboardTableProps {
+  posts: Post[];
+  loading: boolean;
+  error: string | null;
+  selectedCategory: string;
+  searchTerm: string;
+  totalCount: number;
+  getCategoryLabel: (category: PostCategory) => string;
+  getCategoryViewType: (category: PostCategory) => string;
+  onEdit: (post: Post) => void;
+  onDelete: (post: Post) => Promise<void>;
+  onPageChange: (page: number) => void;
+  currentPage: number;
+  totalPages: number;
+  deleteLoading: boolean;
+}
+
+export const DashboardTable = ({
+  posts,
+  loading,
+  error,
+  selectedCategory,
+  searchTerm,
+  totalCount,
+  getCategoryLabel,
+  getCategoryViewType,
+  onEdit,
+  onDelete,
+  onPageChange,
+  currentPage,
+  totalPages,
+  deleteLoading,
+}: DashboardTableProps) => {
+  if (loading) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-gray-500">게시글을 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-red-500">게시글을 불러오는데 실패했습니다: {error}</p>
+      </div>
+    );
+  }
+
+  if (posts.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-gray-500">게시글이 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 결과 정보 */}
+      <div className="text-sm text-gray-600">
+        총 {totalCount}개의 게시글
+        {` (${getCategoryLabel(selectedCategory as PostCategory)} 카테고리)`}
+        {searchTerm && ` - "${searchTerm}" 검색 결과`}
+      </div>
+
+      {/* 게시글 목록 */}
+      {posts.map((post) => (
+        <Card key={post.id} className="p-6">
+          <div className="flex justify-between items-start">
+            <div className="flex-1">
+              <div className="flex items-center space-x-2 mb-2">
+                <Badge variant="outline">{getCategoryLabel(post.category as PostCategory)}</Badge>
+                {getCategoryViewType(post.category as PostCategory) === 'THUMBNAIL' && (
+                  <Badge variant="secondary">썸네일</Badge>
+                )}
+                {post.eventDate && <Badge variant="default">행사</Badge>}
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">{post.title}</h3>
+              {post.thumbnail && (
+                <div className="mb-3">
+                  <img
+                    src={post.thumbnail}
+                    alt="썸네일"
+                    className="w-24 h-24 object-cover rounded"
+                  />
+                </div>
+              )}
+              <p className="text-gray-600 mb-3 line-clamp-2">{post.content}</p>
+              {post.eventDate && (
+                <p className="text-sm text-blue-600 mb-2">
+                  행사일: {new Date(post.eventDate).toLocaleString()}
+                </p>
+              )}
+              <div className="flex items-center space-x-4 text-sm text-gray-500">
+                <span>작성일: {new Date(post.createdAt).toLocaleString()}</span>
+                {post.updatedAt !== post.createdAt && (
+                  <span>수정일: {new Date(post.updatedAt).toLocaleString()}</span>
+                )}
+              </div>
+            </div>
+            <div className="flex space-x-2 ml-4">
+              <Button variant="outline" size="sm" onClick={() => onEdit(post)}>
+                수정
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onDelete(post)}
+                disabled={deleteLoading}
+                className="text-red-600 hover:text-red-700"
+              >
+                {deleteLoading ? '삭제 중...' : '삭제'}
+              </Button>
+            </div>
+          </div>
+        </Card>
+      ))}
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <div className="flex justify-center items-center space-x-2 mt-6">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={currentPage === 0}
+          >
+            이전
+          </Button>
+          <span className="text-sm text-gray-600">
+            {currentPage + 1} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={currentPage === totalPages - 1}
+          >
+            다음
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/admin/Dashboard/index.ts
+++ b/src/components/admin/Dashboard/index.ts
@@ -1,0 +1,3 @@
+export { DashboardHeader } from './DashboardHeader';
+export { DashboardStats } from './DashboardStats';
+export { DashboardTable } from './DashboardTable';

--- a/src/components/admin/EditPost/EditPostForm.tsx
+++ b/src/components/admin/EditPost/EditPostForm.tsx
@@ -1,0 +1,272 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface Post {
+  id: string;
+  title: string;
+  content: string;
+  category: string;
+  createdAt: string;
+  updatedAt: string;
+  author: string;
+  views: number;
+  thumbnail?: string;
+  attachments?: string[];
+  eventDate?: string;
+  activityType?: string;
+}
+
+interface EditPostFormProps {
+  formData: {
+    title: string;
+    content: string;
+    postType: string;
+    eventDate?: string;
+    activityType?: string;
+    thumbnail?: File;
+    attachments?: File[];
+  };
+  originalPost: Post | null;
+  existingFileIds: number[];
+  selectedExistingFiles: number[];
+  updateLoading: boolean;
+  onTitleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onPostTypeChange: (value: string) => void;
+  onEventDateChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFileUpload: (files: FileList | null, type: 'thumbnail' | 'attachments') => void;
+  onExistingFileToggle: (fileId: number) => void;
+  onContentChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onCancel: () => void;
+  categoryInfo: Record<string, { name: string; viewType: string; hasThumbnail: boolean }>;
+}
+
+export const EditPostForm = ({
+  formData,
+  originalPost,
+  existingFileIds,
+  selectedExistingFiles,
+  updateLoading,
+  onTitleChange,
+  onPostTypeChange,
+  onEventDateChange,
+  onFileUpload,
+  onExistingFileToggle,
+  onContentChange,
+  onSubmit,
+  onCancel,
+  categoryInfo,
+}: EditPostFormProps) => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* 헤더 */}
+      <header className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div>
+              <h1 className="text-xl font-semibold text-gray-900">게시글 수정</h1>
+            </div>
+            <div className="flex items-center space-x-4">
+              <span className="text-sm text-gray-600">안녕하세요, 관리자님</span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* 메인 콘텐츠 */}
+      <main className="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <form onSubmit={onSubmit} className="space-y-6">
+            {/* 제목 */}
+            <div>
+              <Label htmlFor="title">제목 *</Label>
+              <Input
+                id="title"
+                value={formData.title}
+                onChange={onTitleChange}
+                placeholder="게시글 제목을 입력하세요"
+                required
+                className="mt-1"
+              />
+            </div>
+
+            {/* 카테고리 */}
+            <div>
+              <Label htmlFor="postType">카테고리 *</Label>
+              <Select value={formData.postType} onValueChange={onPostTypeChange} disabled={true}>
+                <SelectTrigger className="mt-1 bg-gray-100">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(categoryInfo).map(([key, info]) => (
+                    <SelectItem key={key} value={key}>
+                      {info.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-sm text-gray-500 mt-1">게시글 유형은 수정할 수 없습니다.</p>
+            </div>
+
+            {/* 행사 날짜 (CALENDAR 카테고리만) */}
+            {formData.postType === 'CALENDAR' && (
+              <div>
+                <Label htmlFor="eventDate">행사 날짜 *</Label>
+                <Input
+                  id="eventDate"
+                  type="date"
+                  value={formData.eventDate ? formData.eventDate.split('T')[0] : ''}
+                  onChange={onEventDateChange}
+                  required
+                  className="mt-1"
+                />
+              </div>
+            )}
+
+            {/* 썸네일 업로드 (THUMBNAIL 뷰타입만) */}
+            {formData.postType && categoryInfo[formData.postType]?.hasThumbnail && (
+              <div>
+                <Label htmlFor="thumbnail">썸네일 이미지</Label>
+                <Input
+                  id="thumbnail"
+                  type="file"
+                  accept="image/png,image/jpg,image/jpeg"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    onFileUpload(e.target.files, 'thumbnail')
+                  }
+                  className="mt-1"
+                />
+                {formData.thumbnail && (
+                  <div className="mt-3">
+                    <p className="text-sm text-gray-600 mb-2">새 썸네일 미리보기:</p>
+                    <img
+                      src={URL.createObjectURL(formData.thumbnail)}
+                      alt="썸네일 미리보기"
+                      className="w-48 h-48 object-cover rounded border"
+                    />
+                  </div>
+                )}
+                {originalPost?.thumbnail && !formData.thumbnail && (
+                  <div className="mt-3">
+                    <p className="text-sm text-gray-600 mb-2">현재 썸네일:</p>
+                    <img
+                      src={originalPost.thumbnail}
+                      alt="현재 썸네일"
+                      className="w-48 h-48 object-cover rounded border"
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* 첨부파일 업로드 */}
+            <div>
+              <Label htmlFor="attachments">새 첨부파일 추가</Label>
+              <Input
+                id="attachments"
+                type="file"
+                multiple
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  onFileUpload(e.target.files, 'attachments')
+                }
+                className="mt-1"
+              />
+              {formData.attachments && formData.attachments.length > 0 && (
+                <div className="mt-3">
+                  <p className="text-sm text-gray-600 mb-2">새로 선택된 파일:</p>
+                  <ul className="text-sm text-gray-500 space-y-1">
+                    {formData.attachments.map((file, index) => (
+                      <li key={index} className="flex items-center">
+                        <span className="mr-2">📎</span>
+                        {file.name} ({(file.size / 1024).toFixed(1)} KB)
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {originalPost?.attachments && originalPost.attachments.length > 0 && (
+                <div className="mt-3">
+                  <p className="text-sm text-gray-600 mb-2">
+                    기존 첨부파일 (유지할 파일을 선택하세요):
+                  </p>
+                  <ul className="text-sm text-gray-500 space-y-2">
+                    {originalPost.attachments.map((file, index) => {
+                      const fileId =
+                        existingFileIds && existingFileIds.length > index
+                          ? existingFileIds[index]
+                          : undefined;
+                      const isSelected =
+                        fileId !== undefined && selectedExistingFiles.includes(fileId);
+                      return (
+                        <li
+                          key={index}
+                          className="flex items-center justify-between p-2 border rounded-md"
+                        >
+                          <div className="flex items-center">
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              onChange={() => fileId !== undefined && onExistingFileToggle(fileId)}
+                              disabled={fileId === undefined}
+                              className="mr-3"
+                            />
+                            <span className="mr-2">📎</span>
+                            <span className={isSelected ? 'text-gray-900' : 'text-gray-400'}>
+                              {typeof file === 'string' ? file.split('/').pop() : String(file)}
+                            </span>
+                          </div>
+                          <span
+                            className={`text-xs px-2 py-1 rounded ${
+                              isSelected
+                                ? 'bg-green-100 text-green-800'
+                                : 'bg-gray-100 text-gray-500'
+                            }`}
+                          >
+                            {fileId === undefined ? 'ID 없음' : isSelected ? '유지됨' : '제거됨'}
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
+            </div>
+
+            {/* 내용 */}
+            <div>
+              <Label htmlFor="content">내용 *</Label>
+              <Textarea
+                id="content"
+                value={formData.content}
+                onChange={onContentChange}
+                placeholder="게시글 내용을 입력하세요"
+                rows={12}
+                required
+                className="mt-1"
+              />
+            </div>
+
+            {/* 버튼 */}
+            <div className="flex justify-end space-x-4 pt-6 border-t">
+              <Button type="button" variant="outline" onClick={onCancel} disabled={updateLoading}>
+                취소
+              </Button>
+              <Button type="submit" disabled={updateLoading}>
+                {updateLoading ? '수정 중...' : '게시글 수정'}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+};

--- a/src/components/admin/EditPost/index.ts
+++ b/src/components/admin/EditPost/index.ts
@@ -1,0 +1,1 @@
+export { EditPostForm } from './EditPostForm';

--- a/src/components/admin/Login/LoginForm.tsx
+++ b/src/components/admin/Login/LoginForm.tsx
@@ -1,0 +1,88 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface LoginFormProps {
+  username: string;
+  password: string;
+  error: string;
+  isLoading: boolean;
+  onUsernameChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+}
+
+export const LoginForm = ({
+  username,
+  password,
+  error,
+  isLoading,
+  onUsernameChange,
+  onPasswordChange,
+  onSubmit,
+}: LoginFormProps) => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">관리자 로그인</h2>
+          <p className="mt-2 text-sm text-gray-600">화전 관리자 페이지에 로그인하세요</p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>로그인</CardTitle>
+            <CardDescription>관리자 계정으로 로그인하여 시스템에 접근하세요</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={onSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="username">아이디</Label>
+                <Input
+                  id="username"
+                  type="text"
+                  value={username}
+                  onChange={(e) => onUsernameChange(e.target.value)}
+                  placeholder="관리자 아이디를 입력하세요"
+                  required
+                  disabled={isLoading}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">비밀번호</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => onPasswordChange(e.target.value)}
+                  placeholder="비밀번호를 입력하세요"
+                  required
+                  disabled={isLoading}
+                />
+              </div>
+
+              {error && (
+                <div className="text-red-600 text-sm bg-red-50 p-3 rounded-md">{error}</div>
+              )}
+
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? '로그인 중...' : '로그인'}
+              </Button>
+            </form>
+
+            <div className="mt-6 p-4 bg-blue-50 rounded-md">
+              <h4 className="text-sm font-medium text-blue-800 mb-2">데모 계정</h4>
+              <p className="text-xs text-blue-600">
+                아이디: admin
+                <br />
+                비밀번호: admin
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/Login/index.ts
+++ b/src/components/admin/Login/index.ts
@@ -1,0 +1,1 @@
+export { LoginForm } from './LoginForm';

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -1,0 +1,4 @@
+export * from './Login';
+export * from './Dashboard';
+export * from './CreatePost';
+export * from './EditPost';

--- a/src/pages/admin/CreatePost.tsx
+++ b/src/pages/admin/CreatePost.tsx
@@ -1,25 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '@/contexts/AuthContext';
 import { useApi } from '@/hooks/useApi';
 import { postsApi } from '@/api/admin/posts';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Textarea } from '../../components/ui/textarea';
+import { CreatePostForm } from '@/components/admin/CreatePost';
 import type { PostFormData, PostCategory, ActivityType } from './data';
 import { categoryInfo } from './data';
 
 export default function CreatePost() {
   const navigate = useNavigate();
-  const { user } = useAuth();
   const [formData, setFormData] = useState<PostFormData>({
     title: '',
     content: '',
@@ -29,16 +17,6 @@ export default function CreatePost() {
   // API 훅들
   const createPostApi = useApi(postsApi.createPost);
   const createCalendarApi = useApi(postsApi.createCalendarPost);
-
-  const handleFileUpload = (files: FileList | null, type: 'thumbnail' | 'attachments') => {
-    if (!files) return;
-
-    if (type === 'thumbnail') {
-      setFormData({ ...formData, thumbnail: files[0] });
-    } else {
-      setFormData({ ...formData, attachments: Array.from(files) });
-    }
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,7 +29,7 @@ export default function CreatePost() {
 
       if (formData.postType === 'CALENDAR') {
         // 캘린더 게시글 생성 (활동 타입 포함)
-        if (!formData.activityType) {
+        if (!formData.activityType || formData.activityType === 'NONE') {
           alert('캘린더 게시글은 활동 타입을 선택해야 합니다.');
           return;
         }
@@ -84,188 +62,27 @@ export default function CreatePost() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* 헤더 */}
-      <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div>
-              <h1 className="text-xl font-semibold text-gray-900">새 게시글 작성</h1>
-            </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-gray-600">안녕하세요, {user?.name}님</span>
-            </div>
-          </div>
-        </div>
-      </header>
-
-      {/* 메인 콘텐츠 */}
-      <main className="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          <form onSubmit={handleSubmit} className="space-y-6">
-            {/* 제목 */}
-            <div>
-              <Label htmlFor="title">제목 *</Label>
-              <Input
-                id="title"
-                value={formData.title}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setFormData({ ...formData, title: e.target.value })
-                }
-                placeholder="게시글 제목을 입력하세요"
-                required
-                className="mt-1"
-              />
-            </div>
-
-            {/* 카테고리 */}
-            <div>
-              <Label htmlFor="postType">카테고리 *</Label>
-              <Select
-                value={formData.postType}
-                onValueChange={(value: PostCategory) =>
-                  setFormData({ ...formData, postType: value })
-                }
-              >
-                <SelectTrigger className="mt-1">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(categoryInfo).map(([key, info]) => (
-                    <SelectItem key={key} value={key}>
-                      {info.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {/* 행사 날짜 (CALENDAR 카테고리만) */}
-            {formData.postType === 'CALENDAR' && (
-              <div>
-                <Label htmlFor="eventDate">행사 날짜 *</Label>
-                <Input
-                  id="eventDate"
-                  type="date"
-                  value={formData.eventDate ? formData.eventDate.split('T')[0] : ''}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setFormData({ ...formData, eventDate: e.target.value })
-                  }
-                  required
-                  className="mt-1"
-                />
-              </div>
-            )}
-
-            {/* 활동 타입 (CALENDAR 카테고리만) */}
-            {formData.postType === 'CALENDAR' && (
-              <div>
-                <Label htmlFor="activityType">활동 타입 *</Label>
-                <Select
-                  value={formData.activityType}
-                  onValueChange={(value: ActivityType) =>
-                    setFormData({ ...formData, activityType: value })
-                  }
-                >
-                  <SelectTrigger className="mt-1">
-                    <SelectValue placeholder="활동 타입을 선택하세요" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="NONE">없음</SelectItem>
-                    <SelectItem value="FESTIVAL">축제</SelectItem>
-                    <SelectItem value="ONE_DAY_CLASS">원데이 클래스</SelectItem>
-                    <SelectItem value="CONFERENCE">컨퍼런스</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-
-            {/* 썸네일 업로드 (THUMBNAIL 뷰타입만) */}
-            {categoryInfo[formData.postType].hasThumbnail && (
-              <div>
-                <Label htmlFor="thumbnail">썸네일 이미지</Label>
-                <Input
-                  id="thumbnail"
-                  type="file"
-                  accept="image/png,image/jpg,image/jpeg"
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    handleFileUpload(e.target.files, 'thumbnail')
-                  }
-                  className="mt-1"
-                />
-                {formData.thumbnail && (
-                  <div className="mt-3">
-                    <p className="text-sm text-gray-600 mb-2">썸네일 미리보기:</p>
-                    <img
-                      src={URL.createObjectURL(formData.thumbnail)}
-                      alt="썸네일 미리보기"
-                      className="w-48 h-48 object-cover rounded border"
-                    />
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* 첨부파일 업로드 */}
-            <div>
-              <Label htmlFor="attachments">첨부파일</Label>
-              <Input
-                id="attachments"
-                type="file"
-                multiple
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleFileUpload(e.target.files, 'attachments')
-                }
-                className="mt-1"
-              />
-              {formData.attachments && formData.attachments.length > 0 && (
-                <div className="mt-3">
-                  <p className="text-sm text-gray-600 mb-2">선택된 파일:</p>
-                  <ul className="text-sm text-gray-500 space-y-1">
-                    {formData.attachments.map((file, index) => (
-                      <li key={index} className="flex items-center">
-                        <span className="mr-2">📎</span>
-                        {file.name} ({(file.size / 1024).toFixed(1)} KB)
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
-
-            {/* 내용 */}
-            <div>
-              <Label htmlFor="content">내용 *</Label>
-              <Textarea
-                id="content"
-                value={formData.content}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  setFormData({ ...formData, content: e.target.value })
-                }
-                placeholder="게시글 내용을 입력하세요"
-                rows={12}
-                required
-                className="mt-1"
-              />
-            </div>
-
-            {/* 버튼 */}
-            <div className="flex justify-end space-x-4 pt-6 border-t">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleCancel}
-                disabled={createPostApi.loading || createCalendarApi.loading}
-              >
-                취소
-              </Button>
-              <Button type="submit" disabled={createPostApi.loading || createCalendarApi.loading}>
-                {createPostApi.loading || createCalendarApi.loading ? '작성 중...' : '게시글 작성'}
-              </Button>
-            </div>
-          </form>
-        </div>
-      </main>
-    </div>
+    <CreatePostForm
+      title={formData.title}
+      content={formData.content}
+      postType={formData.postType}
+      eventDate={formData.eventDate || ''}
+      activityType={formData.activityType || 'NONE'}
+      thumbnail={formData.thumbnail || null}
+      attachments={formData.attachments || []}
+      isLoading={createPostApi.loading || createCalendarApi.loading}
+      categoryInfo={categoryInfo}
+      onTitleChange={(value) => setFormData({ ...formData, title: value })}
+      onContentChange={(value) => setFormData({ ...formData, content: value })}
+      onPostTypeChange={(value) => setFormData({ ...formData, postType: value as PostCategory })}
+      onEventDateChange={(value) => setFormData({ ...formData, eventDate: value })}
+      onActivityTypeChange={(value) =>
+        setFormData({ ...formData, activityType: value as ActivityType })
+      }
+      onThumbnailChange={(file) => setFormData({ ...formData, thumbnail: file || undefined })}
+      onAttachmentsChange={(files) => setFormData({ ...formData, attachments: files })}
+      onSubmit={handleSubmit}
+      onCancel={handleCancel}
+    />
   );
 }

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -3,17 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useApi } from '@/hooks/useApi';
 import { postsApi } from '@/api/admin/posts';
-import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { DashboardHeader, DashboardStats, DashboardTable } from '@/components/admin/Dashboard';
 import type { Post, PostCategory } from './data';
 import { categoryInfo } from './data';
 import type { GetPostsParams } from '@/api/admin/types/posts';
@@ -40,6 +30,9 @@ export default function AdminDashboard() {
         page: page,
         size: postsPerPage,
       };
+
+      console.log('게시글 조회 요청 파라미터:', params);
+      console.log('요청 카테고리:', category);
 
       const result = await getPostsApi.execute(params);
       if (result) {
@@ -117,8 +110,8 @@ export default function AdminDashboard() {
     }
   };
 
-  const handleCategoryChange = (category: PostCategory) => {
-    setSelectedCategory(category);
+  const handleCategoryChange = (category: string) => {
+    setSelectedCategory(category as PostCategory);
     setCurrentPage(0); // 카테고리 변경 시 첫 페이지로 (0부터 시작)
   };
 
@@ -137,181 +130,35 @@ export default function AdminDashboard() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* 헤더 */}
-      <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div>
-              <h1 className="text-xl font-semibold text-gray-900">화전 관리자 대시보드</h1>
-            </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-gray-600">안녕하세요, {user?.realName}님</span>
-              <Button variant="outline" onClick={logout}>
-                로그아웃
-              </Button>
-            </div>
-          </div>
-        </div>
-      </header>
+      <DashboardHeader user={user} onLogout={logout} />
 
-      {/* 메인 콘텐츠 */}
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
-          {/* 상단 액션 버튼 */}
-          <div className="flex justify-between items-center mb-6">
-            <h2 className="text-2xl font-bold text-gray-900">게시글 관리</h2>
-            <Button onClick={handleCreatePost}>새 게시글 작성</Button>
-          </div>
+          <DashboardStats
+            selectedCategory={selectedCategory}
+            searchTerm={searchTerm}
+            categoryInfo={categoryInfo}
+            onCategoryChange={handleCategoryChange}
+            onSearchChange={handleSearchChange}
+            onCreatePost={handleCreatePost}
+          />
 
-          {/* 필터 및 검색 */}
-          <div className="bg-white p-4 rounded-lg shadow-sm mb-6">
-            <div className="flex flex-col sm:flex-row gap-4">
-              {/* 검색 */}
-              <div className="flex-1">
-                <Input
-                  placeholder="제목 또는 내용으로 검색..."
-                  value={searchTerm}
-                  onChange={handleSearchChange}
-                  className="w-full"
-                />
-              </div>
-
-              {/* 카테고리 필터 */}
-              <div className="sm:w-48">
-                <Select value={selectedCategory} onValueChange={handleCategoryChange}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="카테고리 선택" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(categoryInfo).map(([key, info]) => (
-                      <SelectItem key={key} value={key}>
-                        {info.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            {/* 결과 정보 */}
-            <div className="mt-4 text-sm text-gray-600">
-              총 {filteredPosts.length}개의 게시글
-              {` (${getCategoryLabel(selectedCategory)} 카테고리)`}
-              {searchTerm && ` - "${searchTerm}" 검색 결과`}
-            </div>
-          </div>
-
-          {/* 게시글 목록 */}
-          {getPostsApi.loading ? (
-            <div className="text-center py-8">
-              <p className="text-gray-500">게시글을 불러오는 중...</p>
-            </div>
-          ) : getPostsApi.error ? (
-            <div className="text-center py-8">
-              <p className="text-red-500">게시글을 불러오는데 실패했습니다: {getPostsApi.error}</p>
-            </div>
-          ) : paginatedPosts.length > 0 ? (
-            <div className="space-y-4">
-              {paginatedPosts.map((post) => (
-                <Card key={post.id} className="p-6">
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <div className="flex items-center space-x-2 mb-2">
-                        <Badge variant="outline">{getCategoryLabel(post.category)}</Badge>
-                        {getCategoryViewType(post.category) === 'THUMBNAIL' && (
-                          <Badge variant="secondary">썸네일</Badge>
-                        )}
-                        {post.eventDate && <Badge variant="default">행사</Badge>}
-                      </div>
-                      <h3 className="text-lg font-semibold text-gray-900 mb-2">{post.title}</h3>
-                      {post.thumbnail && (
-                        <div className="mb-3">
-                          <img
-                            src={post.thumbnail}
-                            alt="썸네일"
-                            className="w-24 h-24 object-cover rounded"
-                          />
-                        </div>
-                      )}
-                      <p className="text-gray-600 mb-3 line-clamp-2">{post.content}</p>
-                      {post.eventDate && (
-                        <p className="text-sm text-blue-600 mb-2">
-                          행사일: {new Date(post.eventDate).toLocaleString()}
-                        </p>
-                      )}
-                      <div className="flex items-center space-x-4 text-sm text-gray-500">
-                        <span>작성자: {post.author}</span>
-                        <span>조회수: {post.views}</span>
-                        <span>작성일: {new Date(post.createdAt).toLocaleDateString()}</span>
-                        {post.updatedAt !== post.createdAt && (
-                          <span>수정일: {new Date(post.updatedAt).toLocaleDateString()}</span>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex space-x-2 ml-4">
-                      <Button variant="outline" size="sm" onClick={() => handleEditPost(post)}>
-                        수정
-                      </Button>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => handleDeletePost(post)}
-                        disabled={deletePostApi.loading}
-                      >
-                        {deletePostApi.loading ? '삭제 중...' : '삭제'}
-                      </Button>
-                    </div>
-                  </div>
-                </Card>
-              ))}
-            </div>
-          ) : (
-            <div className="text-center py-12">
-              <div className="text-gray-500 text-lg">
-                {searchTerm ? '검색 결과가 없습니다.' : '게시글이 없습니다.'}
-              </div>
-              <div className="text-gray-400 text-sm mt-2">
-                {searchTerm ? '다른 검색어를 시도해보세요.' : '새 게시글을 작성해보세요.'}
-              </div>
-            </div>
-          )}
-
-          {/* 페이징 */}
-          {totalPages > 1 && (
-            <div className="flex justify-center items-center mt-8 space-x-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 0))}
-                disabled={currentPage === 0}
-              >
-                이전
-              </Button>
-
-              <div className="flex space-x-1">
-                {Array.from({ length: totalPages }, (_, i) => i).map((page) => (
-                  <Button
-                    key={page}
-                    variant={currentPage === page ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => setCurrentPage(page)}
-                    className="w-10"
-                  >
-                    {page + 1}
-                  </Button>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages - 1))}
-                disabled={currentPage === totalPages - 1}
-              >
-                다음
-              </Button>
-            </div>
-          )}
+          <DashboardTable
+            posts={paginatedPosts}
+            loading={getPostsApi.loading}
+            error={getPostsApi.error}
+            selectedCategory={selectedCategory}
+            searchTerm={searchTerm}
+            totalCount={filteredPosts.length}
+            getCategoryLabel={getCategoryLabel}
+            getCategoryViewType={getCategoryViewType}
+            onEdit={handleEditPost}
+            onDelete={handleDeletePost}
+            onPageChange={setCurrentPage}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            deleteLoading={deletePostApi.loading}
+          />
         </div>
       </main>
     </div>

--- a/src/pages/admin/EditPost.tsx
+++ b/src/pages/admin/EditPost.tsx
@@ -1,20 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { useAuth } from '@/contexts/AuthContext';
+// import { useAuth } from '@/contexts/AuthContext';
 import { useApi } from '@/hooks/useApi';
 import { postsApi } from '@/api/admin/posts';
 import type { PostDetailResponse } from '@/api/admin/types/posts';
+import { EditPostForm } from '@/components/admin/EditPost';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Textarea } from '../../components/ui/textarea';
 import type { PostFormData, PostCategory, Post } from './data';
 import { categoryInfo } from './data';
 
@@ -22,7 +13,7 @@ export default function EditPost() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
-  const { user } = useAuth();
+  // const { user } = useAuth(); // 사용되지 않음
   const [formData, setFormData] = useState<PostFormData>({
     title: '',
     content: '',
@@ -199,225 +190,21 @@ export default function EditPost() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* 헤더 */}
-      <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div>
-              <h1 className="text-xl font-semibold text-gray-900">게시글 수정</h1>
-            </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-gray-600">안녕하세요, {user?.name}님</span>
-            </div>
-          </div>
-        </div>
-      </header>
-
-      {/* 메인 콘텐츠 */}
-      <main className="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          <form onSubmit={handleSubmit} className="space-y-6">
-            {/* 제목 */}
-            <div>
-              <Label htmlFor="title">제목 *</Label>
-              <Input
-                id="title"
-                value={formData.title}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setFormData({ ...formData, title: e.target.value })
-                }
-                placeholder="게시글 제목을 입력하세요"
-                required
-                className="mt-1"
-              />
-            </div>
-
-            {/* 카테고리 */}
-            <div>
-              <Label htmlFor="postType">카테고리 *</Label>
-              <Select
-                value={formData.postType}
-                onValueChange={(value: PostCategory) =>
-                  setFormData({ ...formData, postType: value })
-                }
-                disabled={true}
-              >
-                <SelectTrigger className="mt-1 bg-gray-100">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(categoryInfo).map(([key, info]) => (
-                    <SelectItem key={key} value={key}>
-                      {info.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-sm text-gray-500 mt-1">게시글 유형은 수정할 수 없습니다.</p>
-            </div>
-
-            {/* 행사 날짜 (CALENDAR 카테고리만) */}
-            {formData.postType === 'CALENDAR' && (
-              <div>
-                <Label htmlFor="eventDate">행사 날짜 *</Label>
-                <Input
-                  id="eventDate"
-                  type="date"
-                  value={formData.eventDate ? formData.eventDate.split('T')[0] : ''}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setFormData({ ...formData, eventDate: e.target.value })
-                  }
-                  required
-                  className="mt-1"
-                />
-              </div>
-            )}
-
-            {/* 썸네일 업로드 (THUMBNAIL 뷰타입만) */}
-            {formData.postType && categoryInfo[formData.postType]?.hasThumbnail && (
-              <div>
-                <Label htmlFor="thumbnail">썸네일 이미지</Label>
-                <Input
-                  id="thumbnail"
-                  type="file"
-                  accept="image/png,image/jpg,image/jpeg"
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    handleFileUpload(e.target.files, 'thumbnail')
-                  }
-                  className="mt-1"
-                />
-                {formData.thumbnail && (
-                  <div className="mt-3">
-                    <p className="text-sm text-gray-600 mb-2">새 썸네일 미리보기:</p>
-                    <img
-                      src={URL.createObjectURL(formData.thumbnail)}
-                      alt="썸네일 미리보기"
-                      className="w-48 h-48 object-cover rounded border"
-                    />
-                  </div>
-                )}
-                {originalPost.thumbnail && !formData.thumbnail && (
-                  <div className="mt-3">
-                    <p className="text-sm text-gray-600 mb-2">현재 썸네일:</p>
-                    <img
-                      src={originalPost.thumbnail}
-                      alt="현재 썸네일"
-                      className="w-48 h-48 object-cover rounded border"
-                    />
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* 첨부파일 업로드 */}
-            <div>
-              <Label htmlFor="attachments">새 첨부파일 추가</Label>
-              <Input
-                id="attachments"
-                type="file"
-                multiple
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  handleFileUpload(e.target.files, 'attachments')
-                }
-                className="mt-1"
-              />
-              {formData.attachments && formData.attachments.length > 0 && (
-                <div className="mt-3">
-                  <p className="text-sm text-gray-600 mb-2">새로 선택된 파일:</p>
-                  <ul className="text-sm text-gray-500 space-y-1">
-                    {formData.attachments.map((file, index) => (
-                      <li key={index} className="flex items-center">
-                        <span className="mr-2">📎</span>
-                        {file.name} ({(file.size / 1024).toFixed(1)} KB)
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {originalPost.attachments && originalPost.attachments.length > 0 && (
-                <div className="mt-3">
-                  <p className="text-sm text-gray-600 mb-2">
-                    기존 첨부파일 (유지할 파일을 선택하세요):
-                  </p>
-                  <ul className="text-sm text-gray-500 space-y-2">
-                    {originalPost.attachments.map((file, index) => {
-                      const fileId =
-                        existingFileIds && existingFileIds.length > index
-                          ? existingFileIds[index]
-                          : undefined;
-                      const isSelected =
-                        fileId !== undefined && selectedExistingFiles.includes(fileId);
-                      return (
-                        <li
-                          key={index}
-                          className="flex items-center justify-between p-2 border rounded-md"
-                        >
-                          <div className="flex items-center">
-                            <input
-                              type="checkbox"
-                              checked={isSelected}
-                              onChange={() =>
-                                fileId !== undefined && handleExistingFileToggle(fileId)
-                              }
-                              disabled={fileId === undefined}
-                              className="mr-3"
-                            />
-                            <span className="mr-2">📎</span>
-                            <span className={isSelected ? 'text-gray-900' : 'text-gray-400'}>
-                              {typeof file === 'string' ? file.split('/').pop() : String(file)}
-                            </span>
-                          </div>
-                          <span
-                            className={`text-xs px-2 py-1 rounded ${
-                              isSelected
-                                ? 'bg-green-100 text-green-800'
-                                : 'bg-gray-100 text-gray-500'
-                            }`}
-                          >
-                            {fileId === undefined ? 'ID 없음' : isSelected ? '유지됨' : '제거됨'}
-                          </span>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              )}
-            </div>
-
-            {/* 내용 */}
-            <div>
-              <Label htmlFor="content">내용 *</Label>
-              <Textarea
-                id="content"
-                value={formData.content}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  setFormData({ ...formData, content: e.target.value })
-                }
-                placeholder="게시글 내용을 입력하세요"
-                rows={12}
-                required
-                className="mt-1"
-              />
-            </div>
-
-            {/* 버튼 */}
-            <div className="flex justify-end space-x-4 pt-6 border-t">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleCancel}
-                disabled={updatePostApi.loading}
-              >
-                취소
-              </Button>
-              <Button type="submit" disabled={updatePostApi.loading}>
-                {updatePostApi.loading ? '수정 중...' : '게시글 수정'}
-              </Button>
-            </div>
-          </form>
-        </div>
-      </main>
-    </div>
+    <EditPostForm
+      formData={formData}
+      originalPost={originalPost}
+      existingFileIds={existingFileIds}
+      selectedExistingFiles={selectedExistingFiles}
+      updateLoading={updatePostApi.loading}
+      onTitleChange={(e) => setFormData({ ...formData, title: e.target.value })}
+      onPostTypeChange={(value) => setFormData({ ...formData, postType: value as PostCategory })}
+      onEventDateChange={(e) => setFormData({ ...formData, eventDate: e.target.value })}
+      onFileUpload={handleFileUpload}
+      onExistingFileToggle={handleExistingFileToggle}
+      onContentChange={(e) => setFormData({ ...formData, content: e.target.value })}
+      onSubmit={handleSubmit}
+      onCancel={handleCancel}
+      categoryInfo={categoryInfo}
+    />
   );
 }

--- a/src/pages/admin/Login.tsx
+++ b/src/pages/admin/Login.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { LoginForm } from '@/components/admin/Login';
 
 export default function AdminLogin() {
   const [username, setUsername] = useState('');
@@ -41,66 +38,14 @@ export default function AdminLogin() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div className="text-center">
-          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">관리자 로그인</h2>
-          <p className="mt-2 text-sm text-gray-600">화전 관리자 페이지에 로그인하세요</p>
-        </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>로그인</CardTitle>
-            <CardDescription>관리자 계정으로 로그인하여 시스템에 접근하세요</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="username">아이디</Label>
-                <Input
-                  id="username"
-                  type="text"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  placeholder="관리자 아이디를 입력하세요"
-                  required
-                  disabled={isLoading}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="password">비밀번호</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="비밀번호를 입력하세요"
-                  required
-                  disabled={isLoading}
-                />
-              </div>
-
-              {error && (
-                <div className="text-red-600 text-sm bg-red-50 p-3 rounded-md">{error}</div>
-              )}
-
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? '로그인 중...' : '로그인'}
-              </Button>
-            </form>
-
-            <div className="mt-6 p-4 bg-blue-50 rounded-md">
-              <h4 className="text-sm font-medium text-blue-800 mb-2">데모 계정</h4>
-              <p className="text-xs text-blue-600">
-                아이디: admin
-                <br />
-                비밀번호: admin
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+    <LoginForm
+      username={username}
+      password={password}
+      error={error}
+      isLoading={isLoading}
+      onUsernameChange={setUsername}
+      onPasswordChange={setPassword}
+      onSubmit={handleSubmit}
+    />
   );
 }


### PR DESCRIPTION
- Login, Dashboard, CreatePost, EditPost 페이지의 UI 로직을 components/admin/로 분리
- 페이지는 데이터 관리와 API 호출만 담당하도록 역할 분리
- UI 코드와 로직 코드는 수정하지 않고 분리만 수행